### PR TITLE
Add custom prompt support to ask command with -p/--prompt flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Custom System Prompts**: New `-p`/`--prompt` flag for `ask` command
+  - Override the default system prompt with a custom prompt from a file
+  - Useful for specialized tasks (security analysis, performance review, domain-specific expertise)
+  - Can be combined with file context (`-f`) and other flags
+  - Examples: `squid ask -p expert.md "question"` or `squid ask -f code.rs -p reviewer.md "review"`
+  - No rebuild required - change prompts on the fly
+  - See `docs/PROMPTS.md` for detailed guide on creating custom prompts
+
 - **Init Command**: Interactive configuration setup via `squid init`
   - Prompts for API URL, API Model, optional API Key, and Log Level
   - Creates `squid.config.json` in the current directory for project settings

--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ squid ask "What is Rust?"
 # With additional context using -m
 squid ask "Explain Rust" -m "Focus on memory safety"
 
+# Use a custom system prompt
+squid ask "Explain Rust" -p custom-prompt.md
+
 # Disable streaming for complete response at once (useful for scripting)
 squid ask "Explain async/await in Rust" --no-stream
 ```
@@ -227,6 +230,9 @@ squid ask -f sample-files/sample.txt "What are the key features mentioned?"
 
 # With additional context using -m
 squid ask -f src/main.rs "What does this do?" -m "Focus on error handling"
+
+# Use a custom system prompt for specialized analysis
+squid ask -f src/main.rs "Review this" -p expert-reviewer-prompt.md
 
 # Disable streaming for complete response
 squid ask -f code.rs --no-stream "Explain what this code does"
@@ -270,6 +276,9 @@ squid ask "Analyze the main.rs file for me"
 # LLM can write files
 squid ask "Create a hello.txt file with 'Hello, World!'"
 # You'll be prompted with a preview: "Allow writing to file: hello.txt?"
+
+# Use custom prompts with tool calling
+squid ask -p expert-coder.md "Read Cargo.toml and suggest optimizations"
 
 # LLM can search for patterns in files using grep
 squid ask "Search for all TODO comments in the src directory"

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -47,6 +47,16 @@ squid ask --file src/main.rs "Explain what this code does"
 squid ask --file src/main.rs "Review this code and suggest improvements"
 ```
 
+### Custom System Prompt
+
+```bash
+# Use a custom system prompt for specialized behavior
+squid ask --prompt custom-prompt.md "Explain Rust ownership"
+
+# Combine with file context
+squid ask -f src/main.rs -p expert-reviewer.md "Review this code"
+```
+
 ### Documentation Questions
 
 ```bash
@@ -138,7 +148,16 @@ squid ask -f CHANGELOG.md "What are the latest changes?"
 
 ## Tips
 
-1. **Be Specific**: The more specific your question, the better the answer
+1. **Use Custom Prompts**: Override the default system prompt for specialized tasks
+   ```bash
+   # Use a domain-specific prompt
+   squid ask -p security-expert.md "Analyze this authentication flow"
+   
+   # Combine with file context for specialized reviews
+   squid ask -f api.rs -p performance-reviewer.md "Review for performance issues"
+   ```
+
+2. **Be Specific**: The more specific your question, the better the answer
    ```bash
    # Good
    squid ask -f main.rs "What does the ask_llm_streaming function do?"
@@ -147,7 +166,7 @@ squid ask -f CHANGELOG.md "What are the latest changes?"
    squid ask -f main.rs "Explain how error handling works in the ask_llm_streaming function"
    ```
 
-2. **Streaming is Default**: Responses stream in real-time. Use `--no-stream` for complete responses
+3. **Streaming is Default**: Responses stream in real-time. Use `--no-stream` for complete responses
    ```bash
    # Default: streaming (watch the response appear in real-time)
    squid ask -f large_file.txt "Provide a detailed analysis"
@@ -156,12 +175,12 @@ squid ask -f CHANGELOG.md "What are the latest changes?"
    squid ask -f large_file.txt --no-stream "Provide a detailed analysis" > analysis.txt
    ```
 
-3. **Combine Context with Questions**: Frame your questions in context
+4. **Combine Context with Questions**: Frame your questions in context
    ```bash
    squid ask -f auth.rs "How does this authentication system prevent CSRF attacks?"
    ```
 
-4. **File Types Supported**: Works with any text-based file
+5. **File Types Supported**: Works with any text-based file
    - Source code (.rs, .py, .js, .go, etc.)
    - Documentation (.md, .txt, .rst)
    - Configuration (.toml, .json, .yaml, .env)

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -10,7 +10,7 @@ Squid uses specialized system prompts to guide the LLM's behavior for different 
 
 ### 1. Ask Command Prompt (`ask-prompt.md`)
 
-**Used by:** `ask` command (default)  
+**Used by:** `ask` command (default, unless overridden with `-p`/`--prompt`)  
 **Location:** `src/assets/ask-prompt.md`  
 **Purpose:** General-purpose assistant with intelligent tool usage
 
@@ -25,6 +25,13 @@ Squid uses specialized system prompts to guide the LLM's behavior for different 
 squid ask "Read Cargo.toml and list dependencies"
 squid ask "What's in the README file?"
 squid ask "Create a notes.txt with my tasks"
+```
+
+**Using a custom prompt instead:**
+```bash
+# Override with your own system prompt
+squid ask -p custom-prompt.md "Your question here"
+squid ask --prompt expert-coder.md -f main.rs "Review this code"
 ```
 
 ---
@@ -123,12 +130,26 @@ squid review styles/main.css
 
 ### Ask Command
 
-The `ask` command always uses `ask-prompt.md` unless a custom system prompt is provided.
+The `ask` command uses `ask-prompt.md` by default, but can be overridden with the `-p`/`--prompt` flag:
+
+```bash
+# Default: uses built-in ask-prompt.md
+squid ask "What is Rust?"
+
+# Custom: uses your own system prompt
+squid ask -p my-prompt.md "What is Rust?"
+```
 
 ```rust
 // In src/main.rs
 const ASK_PROMPT: &str = include_str!("./assets/ask-prompt.md");
 ```
+
+**When to use custom prompts:**
+- Specialized domain knowledge (security expert, performance analyst, etc.)
+- Different response styles (concise, verbose, tutorial-style, etc.)
+- Specific workflows or methodologies
+- Custom tool usage patterns
 
 ### Review Command
 
@@ -148,7 +169,9 @@ fn get_review_prompt_for_file(file_path: &Path) -> &'static str {
 
 ## Customizing Prompts
 
-To customize a prompt:
+### Option 1: Edit Built-in Prompts (Permanent)
+
+To customize the built-in prompts:
 
 1. Edit the corresponding `.md` file in `src/assets/`
 2. Rebuild the project: `cargo build --release`
@@ -165,6 +188,28 @@ cargo build --release
 # Test
 ./target/release/squid review sample-files/example.rs
 ```
+
+### Option 2: Use Custom Prompts (Per-Command)
+
+For the `ask` command, you can use custom prompts without rebuilding:
+
+```bash
+# Create your custom prompt
+cat > security-expert.md << 'EOF'
+You are a security expert specializing in code security analysis.
+Focus on identifying vulnerabilities, security best practices, and potential attack vectors.
+EOF
+
+# Use it with the ask command
+squid ask -p security-expert.md "Review this authentication code"
+squid ask -f auth.rs -p security-expert.md "Find security issues"
+```
+
+**Benefits:**
+- No rebuild required
+- Easy to experiment with different prompts
+- Share prompts with team members
+- Version control your custom prompts
 
 ## Prompt Best Practices
 
@@ -289,6 +334,7 @@ bat src/assets/review-rust.md  # if you have bat installed
 
 ## Version History
 
+- **v0.4.0**: Added `-p`/`--prompt` flag for custom system prompts in `ask` command
 - **v0.3.0**: Added `ask-prompt.md` for intelligent tool usage
 - **v0.3.0**: Initial specialized review prompts (Rust, TypeScript, HTML, CSS)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,8 @@ squid/
 │   ├── test-security.sh    # Security approval tests
 │   ├── test-reviews.sh     # Code review tests
 │   ├── test-config.sh      # Configuration tests
-│   └── test-grep.sh        # Grep functionality tests
+│   ├── test-grep.sh        # Grep functionality tests
+│   └── test-custom-prompt.sh  # Custom prompt tests
 ├── sample-files/       # Example files with intentional issues
 │   ├── example.rs      # Rust example
 │   ├── example.ts      # TypeScript example
@@ -109,6 +110,40 @@ Test script for the grep/search functionality.
 
 ---
 
+### 🎭 Custom Prompt Test (`test-custom-prompt.sh`)
+
+Automated test script that validates the custom system prompt feature (`-p`/`--prompt` flag).
+
+**Usage:**
+```bash
+# From the project root
+./tests/test-custom-prompt.sh
+```
+
+**What it tests:**
+- ✅ Pirate-themed custom prompt (personality change)
+- ✅ Formal academic custom prompt (tone change)
+- ✅ Emoji-based custom prompt (style change)
+- ✅ Custom prompt with file context (`-f` + `-p` combination)
+- ✅ Error handling for missing prompt files
+
+**Output:** Shows responses from different custom prompts, demonstrating that the LLM follows the custom instructions.
+
+**Quick Manual Test:**
+```bash
+# Use the existing test prompt file
+./target/release/squid ask -p tests/test-prompt.md "What is Rust?" --no-stream
+
+# You should see a response in pirate speak!
+
+# Or create your own custom prompt
+echo "You are a pirate. Always respond in pirate speak." > my-prompt.md
+./target/release/squid ask -p my-prompt.md "What is Rust?" --no-stream
+rm my-prompt.md
+```
+
+---
+
 ## Running Tests
 
 ### Prerequisites
@@ -122,6 +157,7 @@ Test script for the grep/search functionality.
    chmod +x tests/test-reviews.sh
    chmod +x tests/test-config.sh
    chmod +x tests/test-grep.sh
+   chmod +x tests/test-custom-prompt.sh
    ```
 
 ### Run All Tests
@@ -138,6 +174,9 @@ Test script for the grep/search functionality.
 
 # Grep tests
 ./tests/test-grep.sh
+
+# Custom prompt tests (automated)
+./tests/test-custom-prompt.sh
 ```
 
 ### Run Specific Tests

--- a/tests/test-custom-prompt.sh
+++ b/tests/test-custom-prompt.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Test script for custom prompt feature
+# Tests the -p/--prompt flag for the ask command
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+echo "================================="
+echo "Custom Prompt Feature Test"
+echo "================================="
+echo ""
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Create temporary test prompts
+echo -e "${BLUE}Creating test prompts...${NC}"
+
+# Test 1: Pirate prompt
+cat > /tmp/pirate-prompt.md << 'EOF'
+You are a pirate assistant. Always respond in pirate speak using terms like "ahoy", "matey", "arr", and "savvy". Be brief and stay in character.
+EOF
+
+# Test 2: Formal prompt
+cat > /tmp/formal-prompt.md << 'EOF'
+You are a formal academic assistant. Respond in a very formal, scholarly tone. Use phrases like "Furthermore", "Indeed", "One must consider", etc. Be brief but formal.
+EOF
+
+# Test 3: Emoji prompt
+cat > /tmp/emoji-prompt.md << 'EOF'
+You are a fun assistant who uses emojis in every response. Start each sentence with a relevant emoji. Be brief and enthusiastic.
+EOF
+
+echo ""
+echo "================================="
+echo "Test 1: Permanent Test Prompt File"
+echo "================================="
+echo -e "${YELLOW}Command: squid ask -p tests/test-prompt.md \"What is Rust?\" --no-stream${NC}"
+echo ""
+./target/release/squid ask -p tests/test-prompt.md "What is Rust?" --no-stream
+echo ""
+
+echo "================================="
+echo "Test 2: Pirate Prompt (Temporary)"
+echo "================================="
+echo -e "${YELLOW}Command: squid ask -p /tmp/pirate-prompt.md \"What is Rust?\" --no-stream${NC}"
+echo ""
+./target/release/squid ask -p /tmp/pirate-prompt.md "What is Rust?" --no-stream
+echo ""
+
+echo "================================="
+echo "Test 3: Formal Academic Prompt"
+echo "================================="
+echo -e "${YELLOW}Command: squid ask -p /tmp/formal-prompt.md \"What is Rust?\" --no-stream${NC}"
+echo ""
+./target/release/squid ask -p /tmp/formal-prompt.md "What is Rust?" --no-stream
+echo ""
+
+echo "================================="
+echo "Test 4: Emoji Prompt"
+echo "================================="
+echo -e "${YELLOW}Command: squid ask -p /tmp/emoji-prompt.md \"Hello\" --no-stream${NC}"
+echo ""
+./target/release/squid ask -p /tmp/emoji-prompt.md "Hello" --no-stream
+echo ""
+
+echo "================================="
+echo "Test 5: Custom Prompt with File Context"
+echo "================================="
+echo -e "${YELLOW}Command: squid ask -f sample-files/sample.txt -p tests/test-prompt.md \"What is this about?\" --no-stream${NC}"
+echo ""
+./target/release/squid ask -f sample-files/sample.txt -p tests/test-prompt.md "What is this about?" --no-stream
+echo ""
+
+echo "================================="
+echo "Test 6: Invalid Prompt File (Error Handling)"
+echo "================================="
+echo -e "${YELLOW}Command: squid ask -p /tmp/nonexistent-prompt.md \"Hello\" --no-stream${NC}"
+echo ""
+./target/release/squid ask -p /tmp/nonexistent-prompt.md "Hello" --no-stream 2>&1 || echo -e "${GREEN}✓ Error handled correctly${NC}"
+echo ""
+
+# Cleanup
+echo -e "${BLUE}Cleaning up temporary files...${NC}"
+rm -f /tmp/pirate-prompt.md /tmp/formal-prompt.md /tmp/emoji-prompt.md
+
+echo ""
+echo "================================="
+echo -e "${GREEN}Custom Prompt Tests Complete!${NC}"
+echo "================================="
+echo ""
+echo "Summary:"
+echo "- Test 1: Permanent test-prompt.md file (pirate speak)"
+echo "- Test 2: Temporary pirate prompt"
+echo "- Test 3: Formal prompt should respond in academic tone"
+echo "- Test 4: Emoji prompt should use emojis"
+echo "- Test 5: Custom prompt with file context"
+echo "- Test 6: Error handling for missing prompt file"
+echo ""
+echo "If all responses matched their expected styles, the feature works correctly!"

--- a/tests/test-prompt.md
+++ b/tests/test-prompt.md
@@ -1,0 +1,24 @@
+# Test Custom System Prompt
+
+You are a pirate assistant who speaks like a pirate in all responses.
+
+## Instructions
+
+- Always respond in pirate speak
+- Use pirate terminology (ahoy, matey, arr, ye, etc.)
+- Be enthusiastic and theatrical
+- Answer questions accurately but maintain the pirate persona
+
+## Example Responses
+
+**User**: "What is Rust?"
+**You**: "Ahoy matey! Rust be a mighty fine programming language, arr! It be known fer memory safety without needin' a garbage collector, savvy? The borrow checker be yer first mate, keepin' ye from sailin' into dangerous waters of memory bugs!"
+
+**User**: "Explain variables"
+**You**: "Arr, variables be like treasure chests where ye store yer booty (data)! In Rust, ye can make 'em mutable with 'mut' if ye want to change what's inside, or keep 'em immutable by default to protect yer treasure, savvy?"
+
+## Remember
+
+- Stay in character at all times
+- Provide accurate technical information
+- Make coding fun and memorable


### PR DESCRIPTION
- Users can override the default system prompt with a custom file
- Updated README, CHANGELOG, EXAMPLES, and PROMPTS docs with usage
- Added automated test script for custom prompt feature
- Improved error handling for missing prompt files