### PR TITLE
Introduce modular prompt architecture with persona.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,11 +62,26 @@ When making changes, **ALWAYS** consider updates to:
 
 These files control LLM behavior and are **critical**:
 
-- `ask-prompt.md` - Instructions for the `ask` command
-- `code-review.md` - Generic code review prompt
+### Modular Prompt Architecture
+
+Squid uses a **modular composition** system (as of v0.4.0):
+
+- `persona.md` - **Shared personality** definition (auto-prepended to all prompts)
+- `ask-prompt.md` - Tool usage instructions for the `ask` command
+- `code-review.md` - Generic code review criteria
 - `review-*.md` - Language-specific review prompts
 
+At runtime, prompts are composed as: `persona.md` + task-specific prompt
+
+**Benefits:**
+- Single source of truth for AI personality
+- Consistent tone across all commands
+- Easier maintenance (update persona once)
+- Task prompts focus only on instructions
+
 **When updating:**
+- **persona.md** - Defines who the assistant is (role, personality, tone)
+- **Task prompts** - Define what to do (instructions, guidelines, examples)
 - Be explicit and clear
 - Use examples
 - Test with the actual LLM
@@ -94,10 +109,11 @@ When adding new tools to `src/tools.rs`:
 1. Add tool definition to `get_tools()`
 2. Add approval prompt in `call_tool()`
 3. Add execution logic in `call_tool()` match statement
-4. **Update `src/assets/ask-prompt.md`** with tool documentation
-5. Update README.md with examples
-6. Update CHANGELOG.md
-7. Update security docs if relevant (docs/SECURITY*.md)
+4. **Update `src/assets/ask-prompt.md`** with tool documentation (instructions only)
+5. Consider if `persona.md` needs updates (usually not - it's about personality, not tools)
+6. Update README.md with examples
+7. Update CHANGELOG.md
+8. Update security docs if relevant (docs/SECURITY*.md)
 
 ## Project-Specific Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Modular Prompt Architecture**: Introduced `persona.md` for shared AI personality
+  - Separated persona definition from task-specific instructions
+  - All prompts now composed at runtime: `persona.md` + task prompt
+  - `ask-prompt.md` now focuses only on tool usage instructions
+  - All review prompts updated to remove conflicting "You are an expert..." statements
+  - Review prompts now use instruction-based headers (e.g., "## Code Review Instructions")
+  - Easier to maintain consistent personality across all commands
+  - Single source of truth for AI assistant behavior and tone
+
 ### Added
 
 - **Personality Enhancement**: Assistant responses now prefixed with squid emoji 🦑

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -6,7 +6,40 @@ This document describes all the system prompts used in the `squid` CLI tool.
 
 Squid uses specialized system prompts to guide the LLM's behavior for different commands. These prompts are stored in `src/assets/` and are compiled into the binary.
 
+### Prompt Architecture
+
+As of v0.4.0, squid uses a **modular prompt composition** system:
+
+- **`persona.md`** - Shared AI assistant personality and role definition
+- **Task-specific prompts** - Instructions for specific commands (`ask-prompt.md`, `code-review.md`, etc.)
+
+At runtime, the persona is automatically combined with the task-specific prompt to create the complete system message:
+
+```
+[PERSONA] + [TASK-SPECIFIC INSTRUCTIONS] = COMPLETE SYSTEM PROMPT
+```
+
+This architecture provides:
+- **Consistency** - Same personality across all commands
+- **Maintainability** - Update persona once, affects all prompts
+- **Clarity** - Separates "who you are" from "what you do"
+
 ## Available Prompts
+
+### 0. Shared Persona (`persona.md`)
+
+**Used by:** All commands (automatically combined with task prompts)  
+**Location:** `src/assets/persona.md`  
+**Purpose:** Define the AI assistant's personality and role
+
+**Content:**
+- Defines the assistant as helpful and professional
+- Introduces the squid 🦑 personality (adaptable, precise, equipped with tools)
+- Sets the tone: friendly yet professional
+
+**Note:** This prompt is automatically prepended to all task-specific prompts at runtime. You don't interact with it directly, but it shapes the assistant's behavior across all commands.
+
+---
 
 ### 1. Ask Command Prompt (`ask-prompt.md`)
 
@@ -334,7 +367,10 @@ bat src/assets/review-rust.md  # if you have bat installed
 
 ## Version History
 
-- **v0.4.0**: Added `-p`/`--prompt` flag for custom system prompts in `ask` command
+- **v0.4.0**: 
+  - Added `-p`/`--prompt` flag for custom system prompts in `ask` command
+  - Introduced modular prompt architecture with `persona.md`
+  - Task prompts now focus on instructions only (persona separated)
 - **v0.3.0**: Added `ask-prompt.md` for intelligent tool usage
 - **v0.3.0**: Initial specialized review prompts (Rust, TypeScript, HTML, CSS)
 

--- a/src/assets/ask-prompt.md
+++ b/src/assets/ask-prompt.md
@@ -1,7 +1,3 @@
-You are a helpful AI assistant with access to file system tools. Your role is to assist users with their questions, code analysis, and file operations.
-
-Think of yourself as a highly intelligent squid 🦑 - adaptable, precise, and equipped with multiple tools to help solve problems. While you bring a touch of personality to your responses, maintain a professional and helpful tone at all times.
-
 ## Available Tools
 
 You have access to the following tools:

--- a/src/assets/code-review.md
+++ b/src/assets/code-review.md
@@ -1,4 +1,6 @@
-You are an expert code reviewer. Analyze the following code and provide constructive feedback, suggestions for improvement, and highlight any potential issues or best practices that should be considered.
+## Code Review Instructions
+
+Analyze the following code and provide constructive feedback, suggestions for improvement, and highlight any potential issues or best practices that should be considered.
 
 **Code Quality:**
 - Clear and descriptive naming conventions

--- a/src/assets/persona.md
+++ b/src/assets/persona.md
@@ -1,0 +1,3 @@
+You are a helpful AI assistant with access to file system tools. Your role is to assist users with their questions, code analysis, and file operations.
+
+Think of yourself as a highly intelligent squid 🦑 - adaptable, precise, and equipped with multiple tools to help solve problems. While you bring a touch of personality to your responses, maintain a professional and helpful tone at all times.

--- a/src/assets/review-css.md
+++ b/src/assets/review-css.md
@@ -1,4 +1,6 @@
-You are an expert CSS code reviewer. Analyze the following CSS code and provide constructive feedback focusing on:
+## CSS Code Review Instructions
+
+Analyze the following CSS code and provide constructive feedback focusing on:
 
 **CSS Best Practices:**
 - Use of modern CSS features (Grid, Flexbox, Custom Properties)

--- a/src/assets/review-html.md
+++ b/src/assets/review-html.md
@@ -1,4 +1,6 @@
-You are an expert HTML code reviewer. Analyze the following HTML code and provide constructive feedback focusing on:
+## HTML Code Review Instructions
+
+Analyze the following HTML code and provide constructive feedback focusing on:
 
 **Semantic HTML:**
 - Proper use of semantic elements (header, nav, main, article, section, aside, footer)

--- a/src/assets/review-rust.md
+++ b/src/assets/review-rust.md
@@ -1,4 +1,6 @@
-You are an expert Rust code reviewer. Analyze the following code and provide constructive feedback focusing on:
+## Rust Code Review Instructions
+
+Analyze the following Rust code and provide constructive feedback focusing on:
 
 **Rust Idioms & Best Practices:**
 - Proper use of ownership, borrowing, and lifetimes

--- a/src/assets/review-typescript.md
+++ b/src/assets/review-typescript.md
@@ -1,4 +1,6 @@
-You are an expert TypeScript/JavaScript code reviewer. Analyze the following code and provide constructive feedback focusing on:
+## TypeScript/JavaScript Code Review Instructions
+
+Analyze the following TypeScript/JavaScript code and provide constructive feedback focusing on:
 
 **Code Quality & Best Practices:**
 - Proper use of TypeScript types and interfaces


### PR DESCRIPTION
- Separate persona from task-specific instructions in prompts
- Add persona.md for shared AI assistant personality and tone
- Update all review prompts to use instruction-based headers
- Update ask-prompt.md to focus only on tool usage instructions
- Compose prompts at runtime: persona.md + task prompt
- Update docs and CHANGELOG to reflect new architecture
- Refactor main.rs to combine persona and task prompts automatically