### PR TITLE
Add server.allow_network option to control local network access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - RAG toggle button hidden in chat input when RAG is disabled
   - RAG documents menu button hidden when RAG is disabled
   - API config endpoint returns RAG enabled status
+- **Server Network Configuration**: Control whether the web server is accessible from local network
+  - New `server.allow_network` setting in `squid.config.json` (default: `false`)
+  - Environment variable `SQUID_SERVER_ALLOW_NETWORK` takes precedence over config file
+  - When disabled (default), server binds to `127.0.0.1` (localhost only)
+  - When enabled, server binds to `0.0.0.0` (accessible from local network)
+  - Console output clearly indicates network accessibility mode
+  - Improves security by requiring explicit opt-in for network access
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ services:
 **Customization options:**
 - Adjust GPU layers, context window, log level, or database path by editing `docker-compose.yml`
 - Disable GPU acceleration by setting `--n-gpu-layers` to `0` for CPU-only inference
+- Allow network access by setting `SQUID_SERVER_ALLOW_NETWORK=true` (binds to 0.0.0.0 instead of 127.0.0.1)
 
 **Important**: Environment variables defined in `docker-compose.yml` always override any `squid.config.json` file in the workspace. This ensures Docker configuration takes precedence.
 
@@ -404,6 +405,25 @@ See **[CLI Reference - Init Command](docs/CLI.md#init-command)**.
     ```
   - Or via environment variable: `ENABLE_ENV_CONTEXT=false`
   - **Note**: Even when enabled, hostname and working directory are excluded by default for privacy
+
+- `server.allow_network`: Allow server to be accessible from local network (optional, default: `false`)
+  - When disabled (default), the server binds to `127.0.0.1` (localhost only)
+  - When enabled, the server binds to `0.0.0.0` (accessible from other devices on local network)
+  - **Security Note**: Only enable this if you trust your local network and understand the security implications
+  - Set via `squid.config.json`:
+    ```json
+    {
+      "server": {
+        "allow_network": true
+      }
+    }
+    ```
+  - Or via environment variable (takes precedence): `SQUID_SERVER_ALLOW_NETWORK=true`
+  - Useful when:
+    - Accessing the Web UI from a mobile device or tablet on the same network
+    - Running Squid on a server and accessing it from other computers
+    - Testing the Web UI across different devices
+  - The console output indicates whether the server is accessible from the local network
 
 ### Agents
 

--- a/squid.config.json
+++ b/squid.config.json
@@ -17,6 +17,9 @@
     "top_k": 5,
     "documents_path": "documents"
   },
+  "server": {
+    "allow_network": false
+  },
   "agents": {
     "general-assistant": {
       "name": "General Assistant",

--- a/squid.config.json.example
+++ b/squid.config.json.example
@@ -4,6 +4,9 @@
   "log_level": "error",
   "db_log_level": "debug",
   "enable_env_context": true,
+  "server": {
+    "allow_network": false
+  },
   "rag": {
     "enabled": true,
     "embedding_model": "text-embedding-nomic-embed-text-v1.5",

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,27 @@ impl Default for RagConfig {
     }
 }
 
+/// Server configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerConfig {
+    /// Allow server to bind to 0.0.0.0 (accessible from local network)
+    /// When false, server binds to 127.0.0.1 (localhost only)
+    #[serde(default = "default_allow_network")]
+    pub allow_network: bool,
+}
+
+fn default_allow_network() -> bool {
+    false
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            allow_network: default_allow_network(),
+        }
+    }
+}
+
 
 /// Configuration for squid CLI
 ///
@@ -119,6 +140,8 @@ pub struct Config {
     pub enable_env_context: bool,
     #[serde(default)]
     pub rag: RagConfig,
+    #[serde(default)]
+    pub server: ServerConfig,
     #[serde(default, flatten)]
     pub agents: AgentsConfig,
 }
@@ -158,6 +181,7 @@ impl Default for Config {
             database_path: default_database_path(),
             enable_env_context: default_enable_env_context(),
             rag: RagConfig::default(),
+            server: ServerConfig::default(),
             agents: AgentsConfig::default(),
         }
     }
@@ -300,6 +324,14 @@ impl Config {
             config.rag.documents_path = docs_path;
         }
 
+        // Server configuration overrides
+        if let Ok(allow_network) = std::env::var("SQUID_SERVER_ALLOW_NETWORK") {
+            if let Ok(enabled) = allow_network.parse() {
+                debug!("Overriding SQUID_SERVER_ALLOW_NETWORK from environment");
+                config.server.allow_network = enabled;
+            }
+        }
+
         config
     }
 
@@ -412,7 +444,7 @@ impl Config {
     /// Add a tool to an agent's allow list and save config
     pub fn allow_tool_for_agent(&mut self, agent_id: &str, tool_name: &str) -> Result<(), Box<dyn std::error::Error>> {
         let tool_str = tool_name.to_string();
-        
+
         let agent = self.agents.agents.get_mut(agent_id)
             .ok_or_else(|| format!("Agent '{}' not found", agent_id))?;
 
@@ -431,7 +463,7 @@ impl Config {
     /// Add a tool to an agent's deny list and save config
     pub fn deny_tool_for_agent(&mut self, agent_id: &str, tool_name: &str) -> Result<(), Box<dyn std::error::Error>> {
         let tool_str = tool_name.to_string();
-        
+
         let agent = self.agents.agents.get_mut(agent_id)
             .ok_or_else(|| format!("Agent '{}' not found", agent_id))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -479,6 +479,7 @@ async fn main() {
                 database_path: config::Config::default().database_path,
                 enable_env_context: config::Config::default().enable_env_context,
                 rag: final_rag_config,
+                server: config::Config::default().server,
                 agents: config::Config::default().agents,
             };
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -58,7 +58,11 @@ pub async fn start_server(
         println!("🦑: Working directory set to: {:?}", work_dir);
     }
 
-    let bind_address = format!("0.0.0.0:{}", port);
+    let bind_address = if app_config.server.allow_network {
+        format!("0.0.0.0:{}", port)
+    } else {
+        format!("127.0.0.1:{}", port)
+    };
     let mut app_config = app_config;
 
     // Override database path if specified via CLI
@@ -145,7 +149,11 @@ pub async fn start_server(
     });
 
     println!("🦑: Starting Squid Web UI...");
-    println!("🌐 Server running at: http://{}", bind_address);
+    if app_config.server.allow_network {
+        println!("🌐 Server running at: http://{} (accessible from local network)", bind_address);
+    } else {
+        println!("🌐 Server running at: http://{} (localhost only)", bind_address);
+    }
     println!("📡 API endpoint: http://{}/api/chat", bind_address);
     println!("Press Ctrl+C to stop the server\n");
 


### PR DESCRIPTION
- New `server.allow_network` config and env var for network binding
- Defaults to localhost-only for improved security
- Console output indicates accessibility mode
- Updated README and config examples