### PR TITLE
feat: per-agent use_tools option with Shakespeare demo agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-Agent `use_tools` Option**: Agents now support a `use_tools: false` boolean flag to disable all tool usage entirely for that agent. When disabled, the Tools toggle button is hidden in the Web UI and tool support is enforced off server-side regardless of the client request
+- **William Shakespeare Demo Agent**: Added a new `shakespeare` demo agent (alongside the existing `pirate`) showcasing a fully custom persona prompt with `use_tools: false` — the Bard speaks only in Elizabethan English with no tool access
 - **Template Variables in Agent Prompts**: Agent prompts now support variable substitution using the Tera template engine with secure, privacy-safe system variables like `{{persona}}` (base personality), `{{now}}`, `{{os}}`, `{{arch}}`, `{{date}}`, etc.
 - **Tools Toggle Button**: Added toggle button to enable/disable AI tools in chat sessions, disabled by default for user control
 - **Automatic Document Reindexing**: RAG system monitors documents folder and automatically reindexes files when changed

--- a/README.md
+++ b/README.md
@@ -436,11 +436,16 @@ See **[CLI Reference - Init Command](docs/CLI.md#init-command)**.
         "pirate": {
           "name": "Captain Squidbeard",
           "prompt": "Ye be Captain Squidbeard 🏴‍☠️, a cunning pirate squid sailin' the seven seas of code! Speak like a proper pirate..."
+        },
+        "shakespeare": {
+          "name": "William Shakespeare",
+          "use_tools": false,
+          "prompt": "Thou art William Shakespeare, the immortal Bard of Avon ✍️. Speak always in the eloquent style of the Elizabethan age..."
         }
       }
     }
     ```
-    This creates an agent with no inherited guidelines—useful for demos, experiments, or highly specialized personalities.
+    This creates agents with no inherited guidelines — useful for demos, experiments, or highly specialized personalities. Pair with `"use_tools": false` for persona agents that should never invoke tools; the Tools button will be hidden automatically in the Web UI.
     ![Custom Prompt](docs/assets/custom-prompts-pirate.png)
   - Templates use Tera syntax - see [Tera documentation](https://keats.github.io/tera/) for advanced features
 
@@ -523,6 +528,12 @@ Squid uses an **agent-based architecture** where each agent has its own model, s
 - **prompt** (optional): Custom system prompt for this agent
   - Overrides the default system prompt
   - Defines the agent's personality and behavior
+- **use_tools** (optional): Whether this agent can use tools at all (default: `true`)
+  - When set to `false`, all tool usage is disabled for this agent regardless of `permissions`
+  - The Tools toggle button is hidden in the Web UI for agents with `use_tools: false`
+  - Enforced server-side — the client cannot override this setting
+  - Useful for pure persona agents (e.g. a Shakespeare chatbot) that should never call tools
+  - Example: `"use_tools": false`
 - **permissions**: Tool execution permissions specific to this agent
   - **allow**: Tools this agent can use without confirmation
   - **deny**: Tools this agent cannot use at all
@@ -541,6 +552,7 @@ You can create agents for different purposes:
 - **Safe Explorer** (read-only): Explores and documents code
 - **General Assistant** (full access): Makes code changes and runs commands
 - **Terminal Assistant** (command specialist): Focused on bash operations with specific command allowlists
+- **Persona Agent** (no tools): A fully custom personality with `use_tools: false` — e.g. a Shakespearean bard or a pirate
 
 
 

--- a/squid.config.json
+++ b/squid.config.json
@@ -77,6 +77,20 @@
         "allow": ["bash:date"],
         "deny": []
       }
+    },
+    "shakespeare": {
+      "name": "William Shakespeare",
+      "enabled": true,
+      "description": "A renaissance bard who speaks in Shakespearean English (no tools)",
+      "model": "qwen3.5-4b",
+      "context_window": 8192,
+      "pricing_model": "gpt-4o-mini",
+      "use_tools": false,
+      "prompt": "Thou art William Shakespeare, the immortal Bard of Avon ✍️. Speak always in the eloquent style of the Elizabethan age — employ 'thee', 'thou', 'thy', 'dost', 'hath', 'wherefore', 'forsooth', and 'prithee' as befitteth a poet of the Globe Theatre. Be helpful and wise, yet never abandon thine poetic tongue. Keep thy answers brief and elegant unless the questioner doth seek greater depth.",
+      "permissions": {
+        "allow": [],
+        "deny": []
+      }
     }
   },
   "default_agent": "general-assistant"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -33,6 +33,10 @@ pub struct AgentConfig {
     pub context_window: Option<u32>,
     #[serde(default)]
     pub permissions: AgentPermissions,
+    /// Whether this agent can use tools (default: true).
+    /// Set to false to disable all tool usage for this agent.
+    #[serde(default = "default_true")]
+    pub use_tools: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -375,7 +375,7 @@ pub async fn chat_stream(
 
     let question = body.message.clone();
     let use_rag = body.use_rag.unwrap_or(false);
-    let use_tools = body.use_tools.unwrap_or(false);
+    let mut use_tools = body.use_tools.unwrap_or(false);
 
     // Validate file sizes (10MB limit per file)
     const MAX_FILE_SIZE: usize = 10 * 1024 * 1024;
@@ -403,6 +403,10 @@ pub async fn chat_stream(
     let (model_id, context_window) = match app_config_clone.get_agent(&agent_id) {
         Some(agent) => {
             let ctx_window = agent.context_window.unwrap_or(app_config_clone.context_window);
+            // Enforce agent-level use_tools setting: if the agent disables tools, override the client request
+            if !agent.use_tools {
+                use_tools = false;
+            }
             (agent.model.clone(), ctx_window)
         }
         None => {
@@ -1439,6 +1443,7 @@ pub struct AgentInfo {
     pub description: String,
     pub model: String,
     pub enabled: bool,
+    pub use_tools: bool,
     pub permissions: crate::agent::AgentPermissions,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pricing_model: Option<String>,
@@ -1468,6 +1473,7 @@ pub async fn get_agents(
             description: agent.description.clone(),
             model: agent.model.clone(),
             enabled: agent.enabled,
+            use_tools: agent.use_tools,
             permissions: agent.permissions.clone(),
             pricing_model: agent.pricing_model.clone(),
             context_window: agent.context_window,

--- a/src/main.rs
+++ b/src/main.rs
@@ -482,6 +482,7 @@ async fn main() {
                         ],
                         deny: vec![],
                     },
+                    use_tools: true,
                 },
             );
 
@@ -505,6 +506,7 @@ async fn main() {
                             "write_file".to_string(),
                         ],
                     },
+                    use_tools: true,
                 },
             );
 
@@ -524,6 +526,7 @@ async fn main() {
                         ],
                         deny: vec![],
                     },
+                    use_tools: true,
                 },
             );
 
@@ -543,6 +546,25 @@ async fn main() {
                         ],
                         deny: vec![],
                     },
+                    use_tools: true,
+                },
+            );
+
+            agents.insert(
+                "shakespeare".to_string(),
+                agent::AgentConfig {
+                    name: "William Shakespeare".to_string(),
+                    enabled: true,
+                    description: "A renaissance bard who speaks in Shakespearean English (no tools)".to_string(),
+                    model: "local-model".to_string(),
+                    prompt: Some("Thou art William Shakespeare, the immortal Bard of Avon ✍️. Speak always in the eloquent style of the Elizabethan age — employ 'thee', 'thou', 'thy', 'dost', 'hath', 'wherefore', 'forsooth', and 'prithee' as befitteth a poet of the Globe Theatre. Be helpful and wise, yet never abandon thine poetic tongue. Keep thy answers brief and elegant unless the questioner doth seek greater depth.".to_string()),
+                    pricing_model: Some("gpt-4o-mini".to_string()),
+                    context_window: Some(8192),
+                    permissions: agent::AgentPermissions {
+                        allow: vec![],
+                        deny: vec![],
+                    },
+                    use_tools: false,
                 },
             );
 

--- a/web/src/components/app/chatbot.tsx
+++ b/web/src/components/app/chatbot.tsx
@@ -173,6 +173,9 @@ const Chatbot = () => {
 
   const selectedAgentData = useMemo(() => agents.find((a) => a.id === selectedAgent), [selectedAgent, agents]);
 
+  // Whether the currently selected agent supports tools (defaults to true if not specified)
+  const agentSupportsTools = useMemo(() => selectedAgentData?.use_tools !== false, [selectedAgentData]);
+
   // Deduplicate sources by filename and combine chunks
   const deduplicateSources = useCallback((sources: Array<{ href: string; title: string; content: string }>) => {
     if (!sources || sources.length === 0) {
@@ -833,19 +836,21 @@ const Chatbot = () => {
                     <span>RAG</span>
                   </PromptInputButton>
                 )}
-                <PromptInputButton
-                  onClick={handleToolsToggle}
-                  tooltip={{
-                    content: useTools
-                      ? 'Tools enabled - AI can use tools to help answer your questions'
-                      : 'Enable Tools to allow AI to use tools',
-                    side: 'top',
-                  }}
-                  variant={useTools ? 'default' : 'ghost'}
-                >
-                  <WrenchIcon size={16} />
-                  <span>Tools</span>
-                </PromptInputButton>
+                {agentSupportsTools && (
+                  <PromptInputButton
+                    onClick={handleToolsToggle}
+                    tooltip={{
+                      content: useTools
+                        ? 'Tools enabled - AI can use tools to help answer your questions'
+                        : 'Enable Tools to allow AI to use tools',
+                      side: 'top',
+                    }}
+                    variant={useTools ? 'default' : 'ghost'}
+                  >
+                    <WrenchIcon size={16} />
+                    <span>Tools</span>
+                  </PromptInputButton>
+                )}
                 <ModelSelector onOpenChange={setAgentSelectorOpen} open={agentSelectorOpen}>
                   <ModelSelectorTrigger asChild>
                     <PromptInputButton>

--- a/web/src/lib/chat-api.ts
+++ b/web/src/lib/chat-api.ts
@@ -548,6 +548,7 @@ export interface AgentInfo {
   description: string;
   model: string;
   enabled: boolean;
+  use_tools: boolean;
   permissions: {
     allow: string[];
     deny: string[];


### PR DESCRIPTION
## Summary

Adds a `use_tools` boolean field (default `true`) to agent configuration, allowing tool support to be toggled on or off at the agent level.

## Changes

### Backend
- Added `use_tools: bool` (default `true`) to `AgentConfig` in `src/agent.rs`
- Exposed `use_tools` in the `AgentInfo` API response (`/api/agents`)
- Server-side enforcement in `chat_stream`: if the agent has `use_tools: false`, the client request is overridden regardless of what was sent
- Added `use_tools: true` to the four default agents created by `squid init`

### Frontend
- Added `use_tools` to the `AgentInfo` TypeScript interface
- Derived `agentSupportsTools` in `chatbot.tsx` — hides the Tools toggle button entirely when the agent does not support tools

### Config & Docs
- Added `shakespeare` demo agent to `squid.config.json` and `main.rs` init defaults with `use_tools: false` and a Shakespearean persona prompt (companion to the existing `pirate` agent)
- Updated README to document the new `use_tools` agent property
- Updated CHANGELOG with entries for `use_tools` and the Shakespeare demo agent

Closes #122