### PR TITLE
feat: per-agent suggestions for chat and file viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-Agent Suggestions**: Agents can now define a `suggestions` list in their config — curated prompt suggestions shown in the Web UI that change automatically when switching agents. Agents with no suggestions configured show no suggestion bar
 - **Per-Agent `use_tools` Option**: Agents now support a `use_tools: false` boolean flag to disable all tool usage entirely for that agent. When disabled, the Tools toggle button is hidden in the Web UI and tool support is enforced off server-side regardless of the client request
 - **William Shakespeare Demo Agent**: Added a new `shakespeare` demo agent (alongside the existing `pirate`) showcasing a fully custom persona prompt with `use_tools: false` — the Bard speaks only in Elizabethan English with no tool access
 - **Template Variables in Agent Prompts**: Agent prompts now support variable substitution using the Tera template engine with secure, privacy-safe system variables like `{{persona}}` (base personality), `{{now}}`, `{{os}}`, `{{arch}}`, `{{date}}`, etc.

--- a/README.md
+++ b/README.md
@@ -496,6 +496,11 @@ Squid uses an **agent-based architecture** where each agent has its own model, s
       "model": "qwen2.5-coder-7b-instruct",
       "context_window": 32768,
       "pricing_model": "gpt-4o",
+      "suggestions": [
+        "Read and summarize the main source files",
+        "Show me the recent git log",
+        "Find all TODO comments in the codebase"
+      ],
       "permissions": {
         "allow": ["now", "read_file", "write_file", "grep", "bash"],
         "deny": []
@@ -534,6 +539,12 @@ Squid uses an **agent-based architecture** where each agent has its own model, s
   - Enforced server-side — the client cannot override this setting
   - Useful for pure persona agents (e.g. a Shakespeare chatbot) that should never call tools
   - Example: `"use_tools": false`
+- **suggestions** (optional): A list of suggested prompts displayed in the Web UI for this agent
+  - Shown as clickable chips above the input box when no messages have been sent yet
+  - Automatically updates when the user switches agents
+  - Agents with no `suggestions` field show no suggestion bar
+  - Tailor suggestions to each agent's capabilities (e.g. code-related prompts for a code reviewer)
+  - Example: `"suggestions": ["Review this file for security issues", "Find all TODOs"]`
 - **permissions**: Tool execution permissions specific to this agent
   - **allow**: Tools this agent can use without confirmation
   - **deny**: Tools this agent cannot use at all
@@ -873,6 +884,11 @@ Fetches available agents configured in your `squid.config.json` file. Each agent
       "model": "qwen2.5-coder-7b-instruct",
       "enabled": true,
       "pricing_model": "gpt-4o",
+      "suggestions": [
+        "Read and summarize the main source files",
+        "Show me the recent git log",
+        "Find all TODO comments in the codebase"
+      ],
       "permissions": {
         "allow": ["now", "read_file", "write_file", "grep", "bash"],
         "deny": []

--- a/squid.config.json
+++ b/squid.config.json
@@ -38,7 +38,13 @@
           "bash:git"
         ],
         "deny": []
-      }
+      },
+      "suggestions": [
+        "Read and summarize the main source files in this project",
+        "Show me the recent git log",
+        "Find all TODO comments in the codebase",
+        "List all files in the current directory"
+      ]
     },
     "code-reviewer": {
       "name": "Code Reviewer",
@@ -51,7 +57,13 @@
       "permissions": {
         "allow": ["now", "read_file", "grep"],
         "deny": ["write_file", "bash"]
-      }
+      },
+      "suggestions": [
+        "Review this file for security vulnerabilities",
+        "What are the biggest code quality issues here?",
+        "Identify any performance bottlenecks",
+        "Check this code for common anti-patterns"
+      ]
     },
     "light": {
       "name": "Light",
@@ -63,7 +75,13 @@
       "permissions": {
         "allow": ["now"],
         "deny": []
-      }
+      },
+      "suggestions": [
+        "What time is it?",
+        "Give me a quick summary of what you can do",
+        "Explain recursion in simple terms",
+        "What's a good way to stay productive?"
+      ]
     },
     "pirate": {
       "name": "Captain Squidbeard",
@@ -76,7 +94,13 @@
       "permissions": {
         "allow": ["bash:date"],
         "deny": []
-      }
+      },
+      "suggestions": [
+        "What be the time, Captain?",
+        "Tell me a tale of the seven seas!",
+        "How do I navigate this codebase, matey?",
+        "What treasure lies hidden in these files, arr?"
+      ]
     },
     "shakespeare": {
       "name": "William Shakespeare",
@@ -90,7 +114,13 @@
       "permissions": {
         "allow": [],
         "deny": []
-      }
+      },
+      "suggestions": [
+        "Compose a sonnet about the art of coding",
+        "Explain what a function is in thy poetic tongue",
+        "What is the nature of a bug, good Bard?",
+        "Speak to me of the virtues of clean code"
+      ]
     }
   },
   "default_agent": "general-assistant"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -37,6 +37,9 @@ pub struct AgentConfig {
     /// Set to false to disable all tool usage for this agent.
     #[serde(default = "default_true")]
     pub use_tools: bool,
+    /// Optional list of suggested prompts shown in the web UI for this agent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub suggestions: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -1449,6 +1449,8 @@ pub struct AgentInfo {
     pub pricing_model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context_window: Option<u32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub suggestions: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1477,6 +1479,7 @@ pub async fn get_agents(
             permissions: agent.permissions.clone(),
             pricing_model: agent.pricing_model.clone(),
             context_window: agent.context_window,
+            suggestions: agent.suggestions.clone(),
         })
         .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -483,6 +483,7 @@ async fn main() {
                         deny: vec![],
                     },
                     use_tools: true,
+                    suggestions: vec![],
                 },
             );
 
@@ -507,6 +508,7 @@ async fn main() {
                         ],
                     },
                     use_tools: true,
+                    suggestions: vec![],
                 },
             );
 
@@ -527,6 +529,7 @@ async fn main() {
                         deny: vec![],
                     },
                     use_tools: true,
+                    suggestions: vec![],
                 },
             );
 
@@ -547,6 +550,7 @@ async fn main() {
                         deny: vec![],
                     },
                     use_tools: true,
+                    suggestions: vec![],
                 },
             );
 
@@ -565,6 +569,7 @@ async fn main() {
                         deny: vec![],
                     },
                     use_tools: false,
+                    suggestions: vec![],
                 },
             );
 

--- a/web/src/components/app/chatbot.tsx
+++ b/web/src/components/app/chatbot.tsx
@@ -81,17 +81,6 @@ import { useAgentStore } from '@/stores/agent-store';
 import { useChatStore } from '@/stores/chat-store';
 import { useConfigStore } from '@/stores/config-store';
 
-const suggestions = [
-  'What are the latest trends in AI?',
-  'How does machine learning work?',
-  'Explain quantum computing',
-  'Best practices for React development',
-  'Tell me about TypeScript benefits',
-  'How to optimize database queries?',
-  'What is the difference between SQL and NoSQL?',
-  'Explain cloud computing basics',
-];
-
 const AttachmentItem = ({
   attachment,
   onRemove,
@@ -172,6 +161,9 @@ const Chatbot = () => {
   const [sourceContentData, setSourceContentData] = useState<{ title: string; content: string } | null>(null);
 
   const selectedAgentData = useMemo(() => agents.find((a) => a.id === selectedAgent), [selectedAgent, agents]);
+
+  // Suggestions for the currently selected agent
+  const suggestions = useMemo(() => selectedAgentData?.suggestions ?? [], [selectedAgentData]);
 
   // Whether the currently selected agent supports tools (defaults to true if not specified)
   const agentSupportsTools = useMemo(() => selectedAgentData?.use_tools !== false, [selectedAgentData]);
@@ -794,11 +786,13 @@ const Chatbot = () => {
         </Conversation>
       </div>
       <div className="grid shrink-0 gap-4 border-t pt-4">
-        <Suggestions className="px-4">
-          {suggestions.map((suggestion) => (
-            <SuggestionItem key={suggestion} onClick={handleSuggestionClick} suggestion={suggestion} />
-          ))}
-        </Suggestions>
+        {suggestions.length > 0 && (
+          <Suggestions className="px-4">
+            {suggestions.map((suggestion) => (
+              <SuggestionItem key={suggestion} onClick={handleSuggestionClick} suggestion={suggestion} />
+            ))}
+          </Suggestions>
+        )}
         <div className="w-full px-4 pb-4">
           <PromptInput
             globalDrop

--- a/web/src/components/app/file-viewer.tsx
+++ b/web/src/components/app/file-viewer.tsx
@@ -44,17 +44,6 @@ import { useSessionStore } from '@/stores/session-store';
 import { useChatStore } from '@/stores/chat-store';
 import { useAgentStore } from '@/stores/agent-store';
 
-const suggestions = [
-  'Review this file for potential bugs',
-  'Explain what this code does',
-  'Suggest improvements for code quality',
-  'Check for security vulnerabilities',
-  'Analyze the code structure',
-  'Find performance optimization opportunities',
-  'Review coding standards compliance',
-  'Identify potential refactoring areas',
-];
-
 // Detect language from filename
 const getLanguageFromFilename = (filename: string): BundledLanguage => {
   const ext = filename.split('.').pop()?.toLowerCase() || '';
@@ -128,6 +117,9 @@ export function FileViewer() {
   } = useAgentStore();
 
   const selectedAgentData = useMemo(() => agents.find((a) => a.id === selectedAgent), [selectedAgent, agents]);
+
+  // Suggestions for the currently selected agent
+  const suggestions = useMemo(() => selectedAgentData?.suggestions ?? [], [selectedAgentData]);
 
   // Fetch available agents on mount
   useEffect(() => {
@@ -264,9 +256,7 @@ export function FileViewer() {
         )}
         {error && (
           <div className="flex items-center justify-center flex-1">
-            <div className="text-sm text-destructive">
-              Error: {error}
-            </div>
+            <div className="text-sm text-destructive">Error: {error}</div>
           </div>
         )}
         {!loading && !error && content && (
@@ -282,27 +272,12 @@ export function FileViewer() {
                 <ArtifactDescription>{filePath}</ArtifactDescription>
               </div>
               <ArtifactActions>
-                <ArtifactAction
-                  icon={CopyIcon}
-                  label="Copy"
-                  onClick={handleCopy}
-                  tooltip="Copy to clipboard"
-                />
-                <ArtifactAction
-                  icon={DownloadIcon}
-                  label="Download"
-                  onClick={handleDownload}
-                  tooltip="Download file"
-                />
+                <ArtifactAction icon={CopyIcon} label="Copy" onClick={handleCopy} tooltip="Copy to clipboard" />
+                <ArtifactAction icon={DownloadIcon} label="Download" onClick={handleDownload} tooltip="Download file" />
               </ArtifactActions>
             </ArtifactHeader>
             <ArtifactContent className="p-0 flex-1 min-h-0">
-              <CodeBlock
-                className="border-none rounded-none"
-                code={content}
-                language={language}
-                showLineNumbers
-              />
+              <CodeBlock className="border-none rounded-none" code={content} language={language} showLineNumbers />
             </ArtifactContent>
           </Artifact>
         )}
@@ -310,15 +285,15 @@ export function FileViewer() {
 
       {/* Prompt Input Area */}
       <div className="grid shrink-0 gap-4 border-t pt-4">
-        <Suggestions className="px-4">
-          {suggestions.map((suggestion) => (
-            <SuggestionItem key={suggestion} onClick={handleSuggestionClick} suggestion={suggestion} />
-          ))}
-        </Suggestions>
+        {suggestions.length > 0 && (
+          <Suggestions className="px-4">
+            {suggestions.map((suggestion) => (
+              <SuggestionItem key={suggestion} onClick={handleSuggestionClick} suggestion={suggestion} />
+            ))}
+          </Suggestions>
+        )}
         <div className="w-full px-4 pb-4">
-          <PromptInput
-            onSubmit={handlePromptSubmit}
-          >
+          <PromptInput onSubmit={handlePromptSubmit}>
             <PromptInputBody>
               <PromptInputTextarea
                 onChange={handlePromptChange}
@@ -348,7 +323,12 @@ export function FileViewer() {
                               return agentProvider === provider;
                             })
                             .map((a) => (
-                              <AgentItem agent={a} isSelected={selectedAgent === a.id} key={a.id} onSelect={handleAgentSelect} />
+                              <AgentItem
+                                agent={a}
+                                isSelected={selectedAgent === a.id}
+                                key={a.id}
+                                onSelect={handleAgentSelect}
+                              />
                             ))}
                         </ModelSelectorGroup>
                       ))}

--- a/web/src/lib/chat-api.ts
+++ b/web/src/lib/chat-api.ts
@@ -554,6 +554,7 @@ export interface AgentInfo {
     deny: string[];
   };
   pricing_model?: string;
+  suggestions?: string[];
 }
 
 export interface AgentsResponse {


### PR DESCRIPTION
## Summary

Adds support for pluggable suggestion entries per agent, closing #52.

Each agent in `squid.config.json` can now define a `suggestions` list of curated prompt chips that appear above the input box in both the **chat** and the **file viewer**. Suggestions update automatically when the user switches agents. Agents with no `suggestions` field defined show no suggestion bar at all.

## Changes

### Backend (Rust)
- `src/agent.rs` — Added optional `suggestions: Vec<String>` field to `AgentConfig` (skipped in serialization when empty)
- `src/api.rs` — Added `suggestions` to the `AgentInfo` response struct and mapped it through in `get_agents`
- `src/main.rs` — Added `suggestions: vec![]` to the five default `AgentConfig` initialisers created by `squid init`

### Configuration
- `squid.config.json` — Each built-in demo agent now ships with tailored suggestions matching its personality and capabilities

### Frontend (TypeScript / React)
- `web/src/lib/chat-api.ts` — Added `suggestions?: string[]` to the `AgentInfo` interface
- `web/src/components/app/chatbot.tsx` — Removed static `suggestions` array; replaced with a `useMemo` reading `selectedAgentData?.suggestions ?? []`; `<Suggestions>` bar is conditionally rendered only when the agent has suggestions
- `web/src/components/app/file-viewer.tsx` — Same treatment: static array removed, per-agent `useMemo` added, bar hidden when empty

### Docs
- `README.md` — Added `suggestions` to the agent config example, agent properties reference, and the `GET /api/agents` response example
- `CHANGELOG.md` — Added entry under `[Unreleased] > Added`

## How to configure

```json
{
  "agents": {
    "code-reviewer": {
      "name": "Code Reviewer",
      "suggestions": [
        "Review this file for security vulnerabilities",
        "What are the biggest code quality issues here?",
        "Identify any performance bottlenecks"
      ]
    }
  }
}
```

Agents with no `suggestions` key simply show no suggestion bar — fully backwards compatible.