### PR TITLE
fix: preserve multiline text in user messages

### DIFF
--- a/web/src/components/ai-elements/message.tsx
+++ b/web/src/components/ai-elements/message.tsx
@@ -320,22 +320,27 @@ export const MessageBranchPage = ({
   );
 };
 
-export type MessageResponseProps = ComponentProps<typeof Streamdown>;
+export type MessageResponseProps = ComponentProps<typeof Streamdown> & {
+  preserveWhitespace?: boolean;
+};
 
 const streamdownPlugins = { cjk, code, math, mermaid };
 
 export const MessageResponse = memo(
-  ({ className, ...props }: MessageResponseProps) => (
+  ({ className, preserveWhitespace, ...props }: MessageResponseProps) => (
     <Streamdown
       className={cn(
         "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+        preserveWhitespace && "whitespace-pre-wrap",
         className
       )}
       plugins={streamdownPlugins}
       {...props}
     />
   ),
-  (prevProps, nextProps) => prevProps.children === nextProps.children
+  (prevProps, nextProps) =>
+    prevProps.children === nextProps.children &&
+    prevProps.preserveWhitespace === nextProps.preserveWhitespace
 );
 
 MessageResponse.displayName = "MessageResponse";

--- a/web/src/components/app/chatbot.tsx
+++ b/web/src/components/app/chatbot.tsx
@@ -741,7 +741,9 @@ const Chatbot = () => {
                                 !message.thinkingSteps ? (
                                   <Shimmer className="text-muted-foreground">Thinking...</Shimmer>
                                 ) : (
-                                  <MessageResponse>{version.content}</MessageResponse>
+                                  <MessageResponse preserveWhitespace={message.from === 'user'}>
+                                    {version.content}
+                                  </MessageResponse>
                                 )}
                               </MessageContent>
                               {/* Tool approvals for reasoning mode (after content) */}


### PR DESCRIPTION
This PR fixes the issue where multiline text entered with shift+enter in the prompt input was displayed as a single line in the chat history.

## Changes
- Added `preserveWhitespace` prop to `MessageResponse` component
- Applied `whitespace-pre-wrap` CSS for user messages to maintain newlines

## Testing
- Build passes successfully
- User messages with line breaks now display correctly in chat history

fixes #129 