### PR TITLE
chore: remove deprecated api_model configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **`api_model` Configuration**: Removed the deprecated global `api_model` field from `Config` struct and `squid.config.json`. The `API_MODEL` environment variable is no longer recognized. Models are configured exclusively per-agent in the `agents` section of `squid.config.json`. The `/api/config` endpoint no longer returns `api_model`
+
 ## [0.12.0] - 2026-03-31
 
 ### Added
@@ -356,7 +360,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - See [Security Documentation](docs/SECURITY.md#-tool-permissions-allowdeny-lists) for details
 
 - **Mistral API Support**: Works with Mistral's OpenAI-compatible endpoint
-  - Example: `API_URL=https://api.mistral.ai/v1`, `API_MODEL=devstral-2512`
+  - Example: `API_URL=https://api.mistral.ai/v1`
   - Supports all Mistral models
 
 - **Datetime Tool**: New `now` tool for current date/time queries

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ docker compose up -d
 
 The `.env` file configures:
 - **Model endpoints**: `API_URL`, `SQUID_EMBEDDING_URL` (connect to Docker AI models)
-- **Model identifiers**: `API_MODEL`, `SQUID_EMBEDDING_MODEL` (which models to use)
+- **Model identifiers**: `SQUID_EMBEDDING_MODEL` (which embedding model to use)
 
 **Default configuration**:
 - LLM: Qwen2.5-Coder 7B via Docker AI at `http://llm:8080/v1`
@@ -246,17 +246,14 @@ services:
     environment:
       # For LM Studio (running on host)
       - API_URL=http://host.docker.internal:1234/v1
-      - API_MODEL=qwen2.5-coder
       - SQUID_EMBEDDING_URL=http://host.docker.internal:1234/v1
       - SQUID_EMBEDDING_MODEL=nomic-embed-text
-      
+
       # For Ollama (running on host)
       # - API_URL=http://host.docker.internal:11434/v1
-      # - API_MODEL=qwen2.5-coder
-      
+
       # For OpenAI
       # - API_URL=https://api.openai.com/v1
-      # - API_MODEL=gpt-4
       # - API_KEY=your-api-key-here
 ```
 
@@ -357,13 +354,6 @@ See **[CLI Reference - Init Command](docs/CLI.md#init-command)**.
   - OpenAI: `https://api.openai.com/v1`
   - Mistral AI: `https://api.mistral.ai/v1`
   - Other OpenAI-compatible services: Check provider's documentation
-  
-- `API_MODEL`: The model identifier to use (can be overridden in Web UI)
-  - ~~`API_MODEL`~~ **DEPRECATED** (as of v0.12.0): Use agent-specific model configuration instead
-    - CLI commands (`ask`, `review`) now use the default agent's model from `squid.config.json`
-    - Web UI always used agent-specific models
-    - Configure models per-agent in the `agents` section (see [Agents](#agents) below)
-    - **Migration**: Remove `API_MODEL` from `.env` and configure models in `squid.config.json` agents
   
 - `API_KEY`: Your API key
   - Local services (LM Studio, Ollama, Docker): `not-needed`
@@ -1230,7 +1220,6 @@ See **[tests/README.md](tests/README.md)** for complete testing documentation an
 5. Set up your `.env`:
    ```bash
    API_URL=http://127.0.0.1:1234/v1
-   API_MODEL=local-model
    API_KEY=not-needed
    ```
 6. Run:
@@ -1259,7 +1248,6 @@ See **[tests/README.md](tests/README.md)** for complete testing documentation an
 4. Set up your `.env`:
    ```bash
    API_URL=http://localhost:11434/v1
-   API_MODEL=qwen2.5-coder
    API_KEY=not-needed
    ```
 5. Run:
@@ -1280,7 +1268,6 @@ See **[tests/README.md](tests/README.md)** for complete testing documentation an
 2. Set up your `.env`:
    ```bash
    API_URL=https://api.openai.com/v1
-   API_MODEL=gpt-4
    API_KEY=sk-your-api-key-here
    ```
 3. Run:
@@ -1301,7 +1288,6 @@ See **[tests/README.md](tests/README.md)** for complete testing documentation an
 2. Set up your `.env`:
    ```bash
    API_URL=https://api.mistral.ai/v1
-   API_MODEL=devstral-2512
    API_KEY=your-mistral-api-key-here
    ```
 3. Run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,6 @@ services:
     models:
       llm:
         endpoint_var: API_URL # OpenAI-compatible LLM endpoint
-        model_var: API_MODEL # Model identifier for LLM
       embedding:
         endpoint_var: SQUID_EMBEDDING_URL # OpenAI-compatible embedding endpoint
         model_var: SQUID_EMBEDDING_MODEL # Model identifier for embeddings

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -299,7 +299,7 @@ show_status() {
 
     # Show environment variables
     print_info "Model Configuration:"
-    docker compose exec -T squid env 2>/dev/null | grep -E "API_URL|API_MODEL|EMBEDDING_URL|EMBEDDING_MODEL|SQUID_CONTEXT_WINDOW" || true
+    docker compose exec -T squid env 2>/dev/null | grep -E "API_URL|EMBEDDING_URL|EMBEDDING_MODEL|SQUID_CONTEXT_WINDOW" || true
 }
 
 # Stop services
@@ -354,7 +354,7 @@ test_setup() {
     print_info "Checking environment variables..."
     if docker compose exec -T squid env | grep -q "API_URL"; then
         print_success "Environment variables configured"
-        docker compose exec -T squid env | grep -E "API_URL|API_MODEL|EMBEDDING_URL|EMBEDDING_MODEL|SQUID_CONTEXT_WINDOW"
+        docker compose exec -T squid env | grep -E "API_URL|EMBEDDING_URL|EMBEDDING_MODEL|SQUID_CONTEXT_WINDOW"
     else
         print_warning "Environment variables not found"
     fi

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -468,7 +468,6 @@ The `squid.config.json` file created by `squid init`:
 ```json
 {
   "api_url": "http://127.0.0.1:1234/v1",
-  "api_model": "qwen2.5-coder",
   "context_window": 32768,
   "log_level": "error",
   "database_path": "squid.db",
@@ -495,7 +494,6 @@ The `squid.config.json` file created by `squid init`:
 | Field | Type | Description |
 |-------|------|-------------|
 | `api_url` | string | OpenAI-compatible API endpoint URL |
-| `api_model` | string | Model identifier to use |
 | `api_key` | string (optional) | API key for authentication |
 | `context_window` | number | Maximum context window in tokens (global default; can be overridden per-agent) |
 | `log_level` | string | Logging verbosity (error, warn, info, debug, trace) |
@@ -511,7 +509,6 @@ Instead of `squid.config.json`, you can create a `.env` file:
 ```bash
 # OpenAI API Configuration
 API_URL=http://127.0.0.1:1234/v1
-# API_MODEL=local-model  # DEPRECATED: Use agent-specific models in squid.config.json
 API_KEY=not-needed
 SQUID_CONTEXT_WINDOW=32768
 SQUID_DATABASE_PATH=squid.db

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -194,17 +194,14 @@ Make sure your `.env` file is configured:
 ```env
 # For LM Studio (local)
 API_URL=http://127.0.0.1:1234/v1
-API_MODEL=local-model
 API_KEY=not-needed
 
 # For OpenAI
 API_URL=https://api.openai.com/v1
-API_MODEL=gpt-4
 API_KEY=sk-your-key-here
 
 # For Mistral API
 API_URL=https://api.mistral.ai/v1
-API_MODEL=devstral-2512
 API_KEY=your-mistral-api-key-here
 ```
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -137,7 +137,6 @@ Create a `.env` file in the project root:
 
 ```bash
 API_URL=http://127.0.0.1:1234/v1
-API_MODEL=local-model
 API_KEY=not-needed
 SQUID_LOG_LEVEL=error
 ```
@@ -146,7 +145,6 @@ SQUID_LOG_LEVEL=error
 
 ```bash
 API_URL=http://localhost:11434/v1
-API_MODEL=qwen2.5-coder
 API_KEY=not-needed
 SQUID_LOG_LEVEL=error
 ```
@@ -155,7 +153,6 @@ SQUID_LOG_LEVEL=error
 
 ```env
 API_URL=https://api.openai.com/v1
-API_MODEL=gpt-4
 API_KEY=sk-your-actual-api-key-here
 SQUID_LOG_LEVEL=error
 ```
@@ -164,14 +161,13 @@ SQUID_LOG_LEVEL=error
 
 ```env
 API_URL=https://api.mistral.ai/v1
-API_MODEL=devstral-2512
 API_KEY=your-mistral-api-key-here
 SQUID_LOG_LEVEL=error
 ```
 
 ### For Other Providers
 
-Check your provider's documentation for the correct `API_URL`, `API_MODEL`, and `API_KEY` values.
+Check your provider's documentation for the correct `API_URL` and `API_KEY` values.
 
 **Important Notes:**
 - If both `squid.config.json` and `.env` exist, the config file takes precedence
@@ -390,7 +386,7 @@ squid ask "Create a hello.txt file with 'Hello, World!'"
 - **Mistral API**:
   - Check your API key is valid
   - Verify URL: `https://api.mistral.ai/v1`
-- **All providers**: Verify `API_URL`, `API_MODEL`, and `API_KEY` in your `.env` file
+- **All providers**: Verify `API_URL` and `API_KEY` in your `.env` file
 
 ### Response not relevant to file
 - Make sure your question specifically asks about the file content

--- a/docs/RAG_TESTING.md
+++ b/docs/RAG_TESTING.md
@@ -42,7 +42,6 @@ Create `squid.config.json`:
 ```json
 {
   "api_url": "http://127.0.0.1:1234/v1",
-  "api_model": "qwen2.5-coder",
   "context_window": 32768,
   "log_level": "info",
   "database_path": "squid.db",

--- a/documents/getting-started.md
+++ b/documents/getting-started.md
@@ -72,7 +72,6 @@ Squid looks for `squid.config.json` in your project directory:
 ```json
 {
   "api_url": "http://127.0.0.1:1234/v1",
-  "api_model": "qwen2.5-coder-7b-instruct",
   "context_window": 32768,
   "log_level": "info"
 }

--- a/documents/rust-examples.rs
+++ b/documents/rust-examples.rs
@@ -9,7 +9,6 @@ use anyhow::Result;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub api_url: String,
-    pub api_model: String,
     pub api_key: Option<String>,
     pub context_window: u32,
 }
@@ -18,7 +17,6 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             api_url: "http://127.0.0.1:1234/v1".to_string(),
-            api_model: "qwen2.5-coder-7b-instruct".to_string(),
             api_key: None,
             context_window: 8192,
         }

--- a/squid.config.json
+++ b/squid.config.json
@@ -1,9 +1,7 @@
 {
   "api_url": "http://127.0.0.1:1234/v1",
-  "api_model": "qwen/qwen3.5-9b",
   "context_window": 262144,
   "_api_url": "http://localhost:12434/engines/v1",
-  "_api_model": "huggingface.co/bartowski/qwen2.5-coder-7b-instruct-gguf:Q4_K_M",
   "_context_window": 32768,
   "log_level": "info",
   "db_log_level": "debug",

--- a/src/api.rs
+++ b/src/api.rs
@@ -1404,7 +1404,6 @@ pub async fn get_logs(
 #[derive(Debug, Serialize)]
 pub struct ConfigResponse {
     pub api_url: String,
-    pub api_model: String,
     pub context_window: u32,
     pub rag_enabled: bool,
 }
@@ -1415,19 +1414,8 @@ pub async fn get_config(
 ) -> Result<HttpResponse, Error> {
     debug!("Fetching API configuration");
 
-    // Get default agent's model
-    let default_agent_id = &app_config.agents.default_agent;
-    let api_model = match app_config.get_agent(default_agent_id) {
-        Some(agent) => agent.model.clone(),
-        None => {
-            warn!("Default agent '{}' not found, using fallback", default_agent_id);
-            "local-model".to_string()
-        }
-    };
-
     let response = ConfigResponse {
         api_url: app_config.api_url.clone(),
-        api_model,
         context_window: app_config.context_window,
         rag_enabled: app_config.rag.enabled,
     };

--- a/src/assets/demo_docs/example-project.md
+++ b/src/assets/demo_docs/example-project.md
@@ -86,7 +86,6 @@ Embedding documents... ████████████ 4/4
 ```json
 {
   "api_url": "http://127.0.0.1:1234/v1",
-  "api_model": "qwen2.5-coder-7b-instruct",
   "context_window": 32768,
   "rag": {
     "enabled": true,

--- a/src/config.rs
+++ b/src/config.rs
@@ -153,7 +153,6 @@ impl Default for ServerConfig {
 ///
 /// **Fields:**
 /// - `api_url`: Base URL for the LLM API (e.g., `http://127.0.0.1:1234/v1`)
-/// - `api_model`: Model identifier (e.g., `local-model`, `qwen2.5-coder`, `gpt-4`)
 /// - `api_key`: Optional API key (use `None` for local models)
 /// - `context_window`: Maximum context window size in tokens (e.g., `32768` for Qwen2.5-Coder)
 /// - `log_level`: Console logging verbosity (`error`, `warn`, `info`, `debug`, `trace`)
@@ -175,9 +174,6 @@ impl Default for ServerConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub api_url: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[deprecated(since = "0.12.0", note = "Use agent-specific model configuration instead. CLI commands now use the default agent's model.")]
-    pub api_model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
     #[serde(default = "default_context_window")]
@@ -224,7 +220,6 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             api_url: "http://127.0.0.1:1234/v1".to_string(),
-            api_model: None, // Deprecated: use agent-specific models
             api_key: None,
             context_window: default_context_window(),
             log_level: default_log_level(),
@@ -296,12 +291,6 @@ impl Config {
         if let Ok(api_url) = std::env::var("API_URL") {
             debug!("Overriding API_URL from environment");
             config.api_url = api_url;
-        }
-
-        if let Ok(api_model) = std::env::var("API_MODEL") {
-            warn!("⚠️  API_MODEL is deprecated. Use agent-specific model configuration instead. CLI commands now use the default agent's model.");
-            debug!("Overriding API_MODEL from environment (deprecated)");
-            config.api_model = Some(api_model);
         }
 
         if let Ok(api_key) = std::env::var("API_KEY") {
@@ -545,7 +534,6 @@ mod tests {
     fn test_default_config() {
         let config = Config::default();
         assert_eq!(config.api_url, "http://127.0.0.1:1234/v1");
-        assert_eq!(config.api_model, None);
         assert_eq!(config.api_key, None);
         assert_eq!(config.context_window, 8192);
         assert_eq!(config.log_level, "error");

--- a/src/init.rs
+++ b/src/init.rs
@@ -331,7 +331,6 @@ pub async fn run(
 
     let config = crate::config::Config {
         api_url: final_url,
-        api_model: None, // Deprecated: use agent-specific models
         api_key: final_api_key,
         context_window: 32768, // Global default fallback
         log_level: final_log_level,

--- a/tests/test-config.sh
+++ b/tests/test-config.sh
@@ -51,7 +51,6 @@ echo "Test 1: Creating example config file"
 cat > squid.config.json << 'EOF'
 {
   "api_url": "http://test-url:1234/v1",
-  "api_model": "test-model",
   "api_key": "test-key",
   "log_level": "info"
 }
@@ -62,7 +61,6 @@ echo
 # Test 2: Config file parsing
 echo "Test 2: Verifying config file structure"
 run_test "Config has api_url" "grep -q '\"api_url\"' squid.config.json"
-run_test "Config has api_model" "grep -q '\"api_model\"' squid.config.json"
 run_test "Config has api_key" "grep -q '\"api_key\"' squid.config.json"
 run_test "Config has log_level" "grep -q '\"log_level\"' squid.config.json"
 echo
@@ -72,7 +70,6 @@ echo "Test 3: Testing config without optional fields (api_key)"
 cat > squid.config.json << 'EOF'
 {
   "api_url": "http://127.0.0.1:1234/v1",
-  "api_model": "local-model",
   "log_level": "info"
 }
 EOF

--- a/tests/test-permissions.sh
+++ b/tests/test-permissions.sh
@@ -43,7 +43,6 @@ echo "Creating squid.config.json with default permissions..."
 cat > squid.config.json << 'EOF'
 {
   "api_url": "http://127.0.0.1:1234/v1",
-  "api_model": "local-model",
   "log_level": "info",
   "permissions": {
     "allow": ["now"],
@@ -91,7 +90,6 @@ echo "Let's add 'write_file' to the deny list..."
 cat > squid.config.json << 'EOF'
 {
   "api_url": "http://127.0.0.1:1234/v1",
-  "api_model": "local-model",
   "log_level": "info",
   "permissions": {
     "allow": ["now"],

--- a/tests/test-rag.sh
+++ b/tests/test-rag.sh
@@ -20,7 +20,6 @@ if [ ! -f "squid.config.json" ]; then
     cat > squid.config.json <<EOF
 {
   "api_url": "http://127.0.0.1:1234/v1",
-  "api_model": "qwen2.5-coder",
   "api_key": "not-needed",
   "context_window": 32768,
   "log_level": "info",

--- a/web/src/lib/chat-api.ts
+++ b/web/src/lib/chat-api.ts
@@ -588,7 +588,6 @@ export async function fetchAgents(apiUrl: string): Promise<AgentsResponse> {
 
 export interface ConfigResponse {
   api_url: string;
-  api_model: string;
   context_window: number;
   rag_enabled: boolean;
 }
@@ -602,7 +601,7 @@ export interface ConfigResponse {
  * @example
  * ```typescript
  * const config = await fetchConfig('');
- * console.log(`Default model: ${config.api_model}`);
+ * console.log(`Context window: ${config.context_window}`);
  * ```
  */
 export async function fetchConfig(apiUrl: string): Promise<ConfigResponse> {

--- a/web/src/stores/agent-store.test.ts
+++ b/web/src/stores/agent-store.test.ts
@@ -41,7 +41,6 @@ const INITIAL_STATE = {
 /** Minimal valid config response — loadAgents calls fetchConfig in parallel but does not use the result. */
 const STUB_CONFIG = {
   api_url: '',
-  api_model: '',
   context_window: 0,
   rag_enabled: false,
 };

--- a/web/src/stores/config-store.test.ts
+++ b/web/src/stores/config-store.test.ts
@@ -11,7 +11,6 @@ vi.mock('@/lib/chat-api', () => ({
 const INITIAL_STATE = {
   ragEnabled: false,
   apiUrl: '',
-  apiModel: '',
   contextWindow: 0,
   isLoading: false,
   isLoaded: false,
@@ -19,7 +18,6 @@ const INITIAL_STATE = {
 
 const MOCK_CONFIG = {
   api_url: 'http://localhost:8080',
-  api_model: 'gpt-4o',
   context_window: 8192,
   rag_enabled: true,
 };
@@ -39,12 +37,11 @@ describe('useConfigStore', () => {
   // ── Initial state ──────────────────────────────────────────────────────────
 
   it('has the correct initial state', () => {
-    const { ragEnabled, apiUrl, apiModel, contextWindow, isLoading, isLoaded } =
+    const { ragEnabled, apiUrl, contextWindow, isLoading, isLoaded } =
       useConfigStore.getState();
 
     expect(ragEnabled).toBe(false);
     expect(apiUrl).toBe('');
-    expect(apiModel).toBe('');
     expect(contextWindow).toBe(0);
     expect(isLoading).toBe(false);
     expect(isLoaded).toBe(false);
@@ -76,10 +73,9 @@ describe('useConfigStore', () => {
 
     await useConfigStore.getState().loadConfig();
 
-    const { ragEnabled, apiUrl, apiModel, contextWindow } = useConfigStore.getState();
+    const { ragEnabled, apiUrl, contextWindow } = useConfigStore.getState();
     expect(ragEnabled).toBe(true);
     expect(apiUrl).toBe('http://localhost:8080');
-    expect(apiModel).toBe('gpt-4o');
     expect(contextWindow).toBe(8192);
   });
 
@@ -120,7 +116,6 @@ describe('useConfigStore', () => {
       '📋 Configuration loaded:',
       expect.objectContaining({
         ragEnabled: true,
-        apiModel: 'gpt-4o',
         contextWindow: 8192,
       }),
     );
@@ -148,7 +143,7 @@ describe('useConfigStore', () => {
     expect(useConfigStore.getState().ragEnabled).toBe(false);
   });
 
-  it('does not overwrite apiUrl, apiModel, or contextWindow on error', async () => {
+  it('does not overwrite apiUrl or contextWindow on error', async () => {
     // Load a successful config first
     vi.mocked(fetchConfig).mockResolvedValueOnce(MOCK_CONFIG);
     await useConfigStore.getState().loadConfig();
@@ -157,9 +152,8 @@ describe('useConfigStore', () => {
     vi.mocked(fetchConfig).mockRejectedValueOnce(new Error('Network error'));
     await useConfigStore.getState().loadConfig();
 
-    const { apiUrl, apiModel, contextWindow } = useConfigStore.getState();
+    const { apiUrl, contextWindow } = useConfigStore.getState();
     expect(apiUrl).toBe('http://localhost:8080');
-    expect(apiModel).toBe('gpt-4o');
     expect(contextWindow).toBe(8192);
   });
 
@@ -178,14 +172,12 @@ describe('useConfigStore', () => {
   it('reflects the latest config after being called multiple times', async () => {
     vi.mocked(fetchConfig)
       .mockResolvedValueOnce(MOCK_CONFIG)
-      .mockResolvedValueOnce({ ...MOCK_CONFIG, api_model: 'gpt-4o-mini', context_window: 4096 });
+      .mockResolvedValueOnce({ ...MOCK_CONFIG, context_window: 4096 });
 
     await useConfigStore.getState().loadConfig();
-    expect(useConfigStore.getState().apiModel).toBe('gpt-4o');
     expect(useConfigStore.getState().contextWindow).toBe(8192);
 
     await useConfigStore.getState().loadConfig();
-    expect(useConfigStore.getState().apiModel).toBe('gpt-4o-mini');
     expect(useConfigStore.getState().contextWindow).toBe(4096);
   });
 
@@ -200,6 +192,5 @@ describe('useConfigStore', () => {
 
     await useConfigStore.getState().loadConfig();
     expect(useConfigStore.getState().ragEnabled).toBe(true);
-    expect(useConfigStore.getState().apiModel).toBe('gpt-4o');
   });
 });

--- a/web/src/stores/config-store.ts
+++ b/web/src/stores/config-store.ts
@@ -5,7 +5,6 @@ interface ConfigState {
   // State
   ragEnabled: boolean;
   apiUrl: string;
-  apiModel: string;
   contextWindow: number;
   isLoading: boolean;
   isLoaded: boolean;
@@ -18,7 +17,6 @@ export const useConfigStore = create<ConfigState>((set) => ({
   // Initial state
   ragEnabled: false, // default to false to prevent flickering until loaded
   apiUrl: '',
-  apiModel: '',
   contextWindow: 0,
   isLoading: false,
   isLoaded: false,
@@ -31,14 +29,12 @@ export const useConfigStore = create<ConfigState>((set) => ({
       set({
         ragEnabled: config.rag_enabled,
         apiUrl: config.api_url,
-        apiModel: config.api_model,
         contextWindow: config.context_window,
         isLoading: false,
         isLoaded: true,
       });
       console.log('📋 Configuration loaded:', {
         ragEnabled: config.rag_enabled,
-        apiModel: config.api_model,
         contextWindow: config.context_window,
       });
     } catch (error) {


### PR DESCRIPTION
## Summary

Completely removes the deprecated global `api_model` field and `API_MODEL` environment variable support. Models are now configured exclusively per-agent in the `agents` section of `squid.config.json`.

## Changes

### Core
- Remove `api_model` from `Config` struct, `Default` impl, and env var handling
- Remove `api_model` from `ConfigResponse` API endpoint
- Remove `api_model` and `_api_model` from `squid.config.json`

### Documentation
- Update README.md, CLI.md, EXAMPLES.md, QUICKSTART.md, RAG_TESTING.md
- Update example configs in documents/ and demo docs/

### Tests
- Update test-permissions.sh, test-rag.sh, test-config.sh
- Update web frontend config-store.test.ts and agent-store.test.ts

### Docker
- Remove `API_MODEL` from docker-compose model bindings and setup script

### Web Frontend
- Remove `apiModel` from config-store.ts state and loading logic
- Update chat-api.ts ConfigResponse interface

### Changelog
- Added entry to Unreleased section