### PR TITLE
chore: remove session IDs from additional log outputs

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -488,7 +488,7 @@ pub async fn ask_llm_streaming(
         if let Err(e) = database.save_session(sess) {
             debug!("Failed to save session: {}", e);
         } else {
-            debug!("Session saved successfully: {}", sess.id);
+            debug!("Session saved successfully");
         }
 
         // Save user message
@@ -514,7 +514,7 @@ pub async fn ask_llm_streaming(
         if let Err(e) = database.save_message(&sess.id, &user_msg) {
             debug!("Failed to save user message to session: {}", e);
         } else {
-            debug!("User message saved successfully to session {}", sess.id);
+            debug!("User message saved successfully to session");
         }
 
         // Save assistant message
@@ -739,7 +739,7 @@ pub async fn ask_llm(params: LlmQueryParams<'_>) -> Result<String, Box<dyn std::
             if let Err(e) = database.save_session(sess) {
                 debug!("Failed to save session: {}", e);
             } else {
-                debug!("Session saved successfully: {}", sess.id);
+                debug!("Session saved successfully");
             }
 
             // Save user message
@@ -765,7 +765,7 @@ pub async fn ask_llm(params: LlmQueryParams<'_>) -> Result<String, Box<dyn std::
             if let Err(e) = database.save_message(&sess.id, &user_msg) {
                 debug!("Failed to save user message to session: {}", e);
             } else {
-                debug!("User message saved successfully to session {}", sess.id);
+                debug!("User message saved successfully to session");
             }
 
             // Save assistant message (no thinking steps for non-streaming)
@@ -821,7 +821,7 @@ pub async fn ask_llm(params: LlmQueryParams<'_>) -> Result<String, Box<dyn std::
         if let Err(e) = database.save_session(sess) {
             debug!("Failed to save session: {}", e);
         } else {
-            debug!("Session saved successfully: {}", sess.id);
+            debug!("Session saved successfully");
         }
 
         // Save user message
@@ -847,7 +847,7 @@ pub async fn ask_llm(params: LlmQueryParams<'_>) -> Result<String, Box<dyn std::
         if let Err(e) = database.save_message(&sess.id, &user_msg) {
             debug!("Failed to save user message to session: {}", e);
         } else {
-            debug!("User message saved successfully to session {}", sess.id);
+            debug!("User message saved successfully to session");
         }
 
         // Save assistant message
@@ -1109,7 +1109,7 @@ pub async fn run_ask_command(
         error!("Failed to get response: {}", e);
     }
 
-    println!("💾 Session saved: {}", &session.id[..8]);
+    println!("💾 Session saved");
 }
 
 /// Handles the `review` command: validates and reads the file, initialises RAG,
@@ -1284,7 +1284,7 @@ pub async fn run_review_command(
         error!("Failed to get review: {}", e);
     }
 
-    println!("💾 Session saved: {}", &session.id[..8]);
+    println!("💾 Session saved");
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,17 +323,11 @@ async fn main() {
                                             .map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string())
                                             .unwrap_or_else(|| "unknown".to_string());
 
-                                    let session_info = log
-                                        .session_id
-                                        .map(|sid| format!(" [session: {}]", &sid[..8]))
-                                        .unwrap_or_default();
-
                                     println!(
-                                        "[{}] {} {}{}: {}",
+                                        "[{}] {} {}: {}",
                                         timestamp,
                                         log.level.to_uppercase(),
                                         log.target,
-                                        session_info,
                                         log.message
                                     );
                                 }


### PR DESCRIPTION
## Summary
- Removes session ID references from debug log messages in `src/llm.rs`
- Removes session ID display from user-facing output in `src/main.rs`
- Continues the work from #149 to eliminate sensitive data from logs

## Test plan
- [ ] Verify application still functions correctly
- [ ] Check that logs no longer contain session IDs
- [ ] Confirm user output shows "Session saved" without ID suffix