### PR TITLE
feat: Add bundled plugins support with load_bundled config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Environment variable `SQUID_WEB_SOUNDS` overrides config file setting
 - **Enhanced Thinking Indicators**: Randomized thinking messages and visual feedback after tool execution for better UX (inspired by Claude Code/Qwen Code)
 - **Unified Working Directory Configuration**: New `working_dir` config field (default: `./workspace`) with `SQUID_WORKING_DIR` environment variable support. Centralizes workspace path management across CLI, server, and Docker. Plugins now work with relative paths only for enhanced security
+- **Bundled Plugins Support**: Added support for loading plugins bundled with the executable
+  - New `load_bundled` field in `plugins` config section (enabled by default)
+  - Bundled plugins are loaded from the executable's `plugins/` directory
+  - Plugin override priority: workspace > global > bundled
+  - Environment variable `SQUID_PLUGINS_LOAD_BUNDLED` to toggle bundled plugins
 
 ### Changed
 

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,7 @@ use std::time::SystemTime;
 fn main() {
     let static_dir = Path::new("static");
     let web_dir = Path::new("web");
+    let plugins_dir = Path::new("plugins");
 
     // Tell Cargo to re-run this script when web sources or bundled assets change.
     println!("cargo:rerun-if-changed=web/src");
@@ -18,6 +19,7 @@ fn main() {
     println!("cargo:rerun-if-changed=web/tsconfig.node.json");
     println!("cargo:rerun-if-changed=web/vite.config.ts");
     println!("cargo:rerun-if-changed=static");
+    println!("cargo:rerun-if-changed=plugins");
 
     // Attempt to build the web frontend if npm is available and static/ is
     // missing or stale. The build is best-effort: when Node.js is not
@@ -135,6 +137,7 @@ fn main() {
     }
 
     ensure_static_dir(static_dir);
+    copy_bundled_plugins(plugins_dir);
 }
 
 fn web_build_required(web_dir: &Path, static_dir: &Path) -> bool {
@@ -222,4 +225,75 @@ fn which_npm() -> Result<String, ()> {
             }
         })
         .ok_or(())
+}
+
+/// Copy bundled plugins directory to the build output directory.
+/// This ensures plugins are available next to the executable during development.
+fn copy_bundled_plugins(plugins_dir: &Path) {
+    // OUT_DIR points to target/debug/build/<crate>-<hash>/out
+    // We want target/debug/plugins (or target/release/plugins)
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
+
+    // Navigate from OUT_DIR to the profile directory (debug or release)
+    // OUT_DIR: /path/to/target/debug/build/squid-rs-<hash>/out
+    // We want: /path/to/target/debug/plugins
+    let profile_dir = Path::new(&out_dir)
+        .parent() // /path/to/target/debug/build/squid-rs-<hash>
+        .and_then(|p| p.parent()) // /path/to/target/debug/build
+        .and_then(|p| p.parent()) // /path/to/target/debug
+        .expect("Failed to resolve profile directory");
+
+    let dest_plugins = profile_dir.join("plugins");
+
+    if !plugins_dir.exists() {
+        eprintln!(
+            "cargo:warning=Plugins directory does not exist: {}",
+            plugins_dir.display()
+        );
+        return;
+    }
+
+    // Copy plugins if source is newer than destination
+    let needs_copy = !dest_plugins.exists()
+        || latest_modified(plugins_dir)
+            .map(|src_mtime| {
+                latest_modified(&dest_plugins)
+                    .map(|dst_mtime| src_mtime > dst_mtime)
+                    .unwrap_or(true)
+            })
+            .unwrap_or(true);
+
+    if needs_copy {
+        if dest_plugins.exists() {
+            let _ = fs::remove_dir_all(&dest_plugins);
+        }
+
+        if let Err(e) = copy_dir_all(plugins_dir, &dest_plugins) {
+            eprintln!("cargo:warning=Failed to copy plugins directory: {}", e);
+            return;
+        }
+
+        eprintln!(
+            "cargo:warning=Copied bundled plugins to {}",
+            dest_plugins.display()
+        );
+    }
+}
+
+/// Recursively copy a directory
+fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+
+        if ty.is_dir() {
+            copy_dir_all(&src_path, &dst_path)?;
+        } else {
+            fs::copy(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
 }

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -16,12 +16,15 @@ Squid supports a powerful JavaScript-based plugin system that allows you to exte
 
 ### 1. Create a Plugin Directory
 
-Plugins can be stored in two locations:
+Plugins can be stored in three locations:
 
 - **Workspace plugins**: `./plugins/` (project-specific)
 - **Global plugins**: `~/.squid/plugins/` (shared across projects)
+- **Bundled plugins**: Shipped with the executable (when installed from crates)
 
-Workspace plugins override global plugins with the same ID.
+Workspace plugins override global plugins, which override bundled plugins with the same ID.
+
+**Development note**: During development (`cargo build`), the `plugins/` directory is automatically copied to `target/debug/plugins/` so the executable can find bundled plugins alongside global and workspace plugins.
 
 ```bash
 mkdir -p plugins/my-plugin
@@ -503,6 +506,7 @@ Increase timeout in config:
     "enabled": true,
     "load_global": true,
     "load_workspace": true,
+    "load_bundled": true,
     "default_timeout_seconds": 30,
     "max_memory_mb": 128
   }
@@ -512,8 +516,15 @@ Increase timeout in config:
 - **`enabled`**: Enable/disable plugin system
 - **`load_global`**: Load plugins from `~/.squid/plugins/`
 - **`load_workspace`**: Load plugins from `./plugins/`
+- **`load_bundled`**: Load bundled plugins shipped with the executable (default: true)
 - **`default_timeout_seconds`**: Maximum execution time
 - **`max_memory_mb`**: Memory limit per plugin
+
+### Environment Variables
+
+Plugin configuration can be overridden via environment variables:
+
+- **`SQUID_PLUGINS_LOAD_BUNDLED`**: Set to `false` to disable loading bundled plugins (e.g., `SQUID_PLUGINS_LOAD_BUNDLED=false`)
 
 ## Advanced Topics
 

--- a/squid.config.json
+++ b/squid.config.json
@@ -20,6 +20,7 @@
     "enabled": true,
     "load_global": true,
     "load_workspace": true,
+    "load_bundled": true,
     "default_timeout_seconds": 30,
     "max_memory_mb": 128
   },

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,6 +85,9 @@ pub struct PluginsConfig {
     /// Load workspace plugins from ./plugins
     #[serde(default = "default_load_workspace")]
     pub load_workspace: bool,
+    /// Load bundled plugins from executable directory
+    #[serde(default = "default_load_bundled")]
+    pub load_bundled: bool,
     /// Default timeout for plugin execution in seconds
     #[serde(default = "default_plugin_timeout")]
     pub default_timeout_seconds: u64,
@@ -105,6 +108,10 @@ fn default_load_workspace() -> bool {
     true
 }
 
+fn default_load_bundled() -> bool {
+    true
+}
+
 fn default_plugin_timeout() -> u64 {
     30
 }
@@ -119,6 +126,7 @@ impl Default for PluginsConfig {
             enabled: default_plugins_enabled(),
             load_global: default_load_global(),
             load_workspace: default_load_workspace(),
+            load_bundled: default_load_bundled(),
             default_timeout_seconds: default_plugin_timeout(),
             max_memory_mb: default_max_memory_mb(),
         }
@@ -412,6 +420,14 @@ impl Config {
         {
             debug!("Overriding SQUID_WEB_SOUNDS from environment");
             config.web.sounds = enabled;
+        }
+
+        // Plugin configuration overrides
+        if let Ok(load_bundled) = std::env::var("SQUID_PLUGINS_LOAD_BUNDLED")
+            && let Ok(enabled) = load_bundled.parse()
+        {
+            debug!("Overriding SQUID_PLUGINS_LOAD_BUNDLED from environment");
+            config.plugins.load_bundled = enabled;
         }
 
         config

--- a/src/plugins/manager.rs
+++ b/src/plugins/manager.rs
@@ -1,7 +1,9 @@
 use crate::config::Config;
 use crate::plugins::context::PluginContext;
 use crate::plugins::metadata::PluginMetadata;
-use crate::plugins::registry::{PluginRegistry, get_global_plugins_dir, get_workspace_plugins_dir};
+use crate::plugins::registry::{
+    PluginRegistry, get_bundled_plugins_dir, get_global_plugins_dir, get_workspace_plugins_dir,
+};
 use crate::plugins::runtime::PluginRuntime;
 use crate::plugins::validator::SchemaValidator;
 use async_openai::types::chat::{ChatCompletionTool, ChatCompletionTools, FunctionObjectArgs};
@@ -45,6 +47,14 @@ impl PluginManager {
                 workspace_dir.display()
             );
             registry.add_directory(workspace_dir);
+        }
+
+        // 3. Bundled plugins (shipped with executable)
+        if self.config.plugins.load_bundled {
+            if let Some(bundled_dir) = get_bundled_plugins_dir() {
+                debug!("Adding bundled plugin directory: {}", bundled_dir.display());
+                registry.add_directory(bundled_dir);
+            }
         }
 
         // Discover all plugins

--- a/src/plugins/registry.rs
+++ b/src/plugins/registry.rs
@@ -11,6 +11,12 @@ pub struct PluginRegistry {
 
     /// Plugin directories to search
     plugin_dirs: Vec<PathBuf>,
+
+    /// Track which directories are global plugin directories
+    global_dirs: Vec<PathBuf>,
+
+    /// Track which directories are bundled plugin directories
+    bundled_dirs: Vec<PathBuf>,
 }
 
 impl PluginRegistry {
@@ -19,13 +25,21 @@ impl PluginRegistry {
         Self {
             plugins: Arc::new(RwLock::new(HashMap::new())),
             plugin_dirs: Vec::new(),
+            global_dirs: Vec::new(),
+            bundled_dirs: Vec::new(),
         }
     }
 
     /// Add a plugin directory to search
     pub fn add_directory(&mut self, dir: PathBuf) {
         if dir.exists() && dir.is_dir() {
-            self.plugin_dirs.push(dir);
+            self.plugin_dirs.push(dir.clone());
+            // Track the type of directory
+            if self.is_global_dir(&dir) {
+                self.global_dirs.push(dir);
+            } else if self.is_bundled_dir(&dir) {
+                self.bundled_dirs.push(dir);
+            }
         }
     }
 
@@ -75,27 +89,51 @@ impl PluginRegistry {
                             continue;
                         }
 
-                        // Mark if this is a global plugin
+                        // Mark the source of this plugin
                         metadata.is_global = self.is_global_dir(plugin_dir);
+                        let is_bundled = self.is_bundled_dir(plugin_dir);
 
-                        // Check for ID conflicts (workspace plugins override global)
-                        if let Some(existing) = plugins_map.get(&metadata.id)
-                            && metadata.is_global
-                            && !existing.is_global
-                        {
-                            // Don't override workspace plugin with global
-                            debug!(
-                                "Skipping global plugin '{}' - overridden by workspace plugin",
-                                metadata.id
-                            );
-                            continue;
+                        // Check for ID conflicts (workspace plugins override global and bundled)
+                        if let Some(existing) = plugins_map.get(&metadata.id) {
+                            // Workspace plugins override global and bundled
+                            if !metadata.is_global && !is_bundled {
+                                // This is a workspace plugin, it should override
+                                debug!(
+                                    "Workspace plugin '{}' overrides existing plugin",
+                                    metadata.id
+                                );
+                                // Continue to insert, will override existing
+                            } else if metadata.is_global && !existing.is_global {
+                                // Don't override workspace plugin with global or bundled
+                                debug!(
+                                    "Skipping global plugin '{}' - overridden by workspace plugin",
+                                    metadata.id
+                                );
+                                continue;
+                            } else if is_bundled && (!existing.is_global || metadata.is_global) {
+                                // Don't override workspace or global with bundled
+                                debug!(
+                                    "Skipping bundled plugin '{}' - overridden by existing plugin",
+                                    metadata.id
+                                );
+                                continue;
+                            }
                         }
 
+                        let source = if metadata.is_global {
+                            "global"
+                        } else if is_bundled {
+                            "bundled"
+                        } else {
+                            "workspace"
+                        };
+
                         info!(
-                            "Loaded plugin: {} v{} from {}",
+                            "Loaded plugin: {} v{} from {} ({})",
                             metadata.title,
                             metadata.version,
-                            path.display()
+                            path.display(),
+                            source
                         );
 
                         plugins_map.insert(metadata.id.clone(), metadata);
@@ -138,6 +176,16 @@ impl PluginRegistry {
         // Check if path contains .squid (typically ~/.squid/plugins)
         dir.to_string_lossy().contains(".squid")
     }
+
+    /// Check if a directory is a bundled plugin directory
+    fn is_bundled_dir(&self, dir: &Path) -> bool {
+        // Bundled plugins are in the executable directory's plugins subdirectory
+        if let Some(bundled_dir) = get_bundled_plugins_dir() {
+            dir == &bundled_dir
+        } else {
+            false
+        }
+    }
 }
 
 impl Default for PluginRegistry {
@@ -154,6 +202,16 @@ pub fn get_global_plugins_dir() -> Option<PathBuf> {
 /// Get the workspace plugins directory path
 pub fn get_workspace_plugins_dir() -> PathBuf {
     PathBuf::from("./plugins")
+}
+
+/// Get the bundled plugins directory path (relative to executable)
+/// This is used when plugins are bundled with the executable (e.g., from crates.io)
+pub fn get_bundled_plugins_dir() -> Option<PathBuf> {
+    // Get the directory of the current executable
+    std::env::current_exe()
+        .ok()
+        .and_then(|exe_path| exe_path.parent().map(|p| p.to_path_buf()))
+        .map(|exe_dir| exe_dir.join("plugins"))
 }
 
 #[cfg(test)]
@@ -177,5 +235,14 @@ mod tests {
     fn test_workspace_dir() {
         let dir = get_workspace_plugins_dir();
         assert_eq!(dir, PathBuf::from("./plugins"));
+    }
+
+    #[test]
+    fn test_bundled_dir() {
+        let dir = get_bundled_plugins_dir();
+        // Should be in the executable's directory
+        assert!(dir.is_some());
+        let dir = dir.unwrap();
+        assert!(dir.ends_with("plugins"));
     }
 }


### PR DESCRIPTION
## Summary

Adds support for loading plugins bundled with the executable, enabling plugins to ship alongside the binary when installed from crates.

## Changes

- **Config**: Added `load_bundled` field to `PluginsConfig` (enabled by default)
- **Resolution**: Bundled plugins resolved from executable's `plugins/` directory via `get_bundled_plugins_dir()`
- **Build**: `build.rs` copies `plugins/` to `target/debug/plugins/` during development builds
- **Env var**: `SQUID_PLUGINS_LOAD_BUNDLED=false` to disable bundled plugins
- **Priority**: workspace > global > bundled
- **Docs**: Updated PLUGINS.md and CHANGELOG.md