### PR TITLE
feat: Add Agent Viewer to web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Agent Viewer**: View agent prompt files directly in the web UI
+  - New "Agents" section in sidebar lists all available agents with collapsible submenus
+  - Clicking an agent opens a read-only view of its underlying `.md` prompt file
+  - Includes copy-to-clipboard support and syntax-highlighted markdown display
+  - Long prompt lines now wrap properly for readability
+  - New API endpoint: `GET /api/agents/{id}/content`
+
 ## [0.13.0] - 2026-04-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Agent Viewer**: View agent prompt files directly in the web UI
-  - New "Agents" section in sidebar lists all available agents with collapsible submenus
-  - Clicking an agent opens a read-only view of its underlying `.md` prompt file
-  - Includes copy-to-clipboard support and syntax-highlighted markdown display
-  - Long prompt lines now wrap properly for readability
-  - New API endpoint: `GET /api/agents/{id}/content`
+- **Agent Viewer**: View agent prompt files in the web UI via new "Agents" sidebar section
 
 ## [0.13.0] - 2026-04-07
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -202,3 +202,20 @@ Fetch available agents configured in `squid.config.json`.
 - Each agent includes its model, description, and tool permissions (allow-only)
 - Optional `pricing_model` field for cost estimation (useful for local models)
 - Used by Web UI agent selector to display available assistants
+
+### `GET /api/agents/{agent_id}/content`
+
+Fetch the raw markdown prompt content for a specific agent.
+
+**Response:**
+```json
+{
+  "id": "general-assistant",
+  "name": "General Assistant",
+  "content": "---\nname: General Assistant\n...\n---\n\nYou are a helpful coding assistant..."
+}
+```
+
+**Errors:**
+- `404` — Agent not found
+- `500` — Failed to read agent file from disk

--- a/src/api.rs
+++ b/src/api.rs
@@ -1471,7 +1471,17 @@ pub async fn get_agent_content(
     let agent_id = agent_id.into_inner();
     debug!("Fetching content for agent: {}", agent_id);
 
-    // Check if agent exists
+    // Validate agent ID to prevent path traversal (allow only safe characters)
+    if !agent_id
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
+        return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "Invalid agent ID"
+        })));
+    }
+
+    // Check if agent exists in configuration
     let agent = app_config.agents.agents.get(&agent_id);
     if agent.is_none() {
         return Ok(HttpResponse::NotFound().json(serde_json::json!({

--- a/src/api.rs
+++ b/src/api.rs
@@ -1455,6 +1455,46 @@ pub async fn get_agents(app_config: web::Data<Arc<config::Config>>) -> Result<Ht
     }))
 }
 
+/// Response for agent file content
+#[derive(Debug, Serialize)]
+pub struct AgentContentResponse {
+    pub id: String,
+    pub name: String,
+    pub content: String,
+}
+
+/// Get the raw markdown content for a specific agent
+pub async fn get_agent_content(
+    agent_id: web::Path<String>,
+    app_config: web::Data<Arc<config::Config>>,
+) -> Result<HttpResponse, Error> {
+    let agent_id = agent_id.into_inner();
+    debug!("Fetching content for agent: {}", agent_id);
+
+    // Check if agent exists
+    let agent = app_config.agents.agents.get(&agent_id);
+    if agent.is_none() {
+        return Ok(HttpResponse::NotFound().json(serde_json::json!({
+            "error": format!("Agent '{}' not found", agent_id)
+        })));
+    }
+
+    // Read the agent file from the agents directory
+    let agents_dir = crate::agent::get_agents_dir(app_config.config_dir.as_deref());
+    let agent_file = agents_dir.join(format!("{}.md", agent_id));
+
+    match std::fs::read_to_string(&agent_file) {
+        Ok(content) => Ok(HttpResponse::Ok().json(AgentContentResponse {
+            id: agent_id,
+            name: agent.unwrap().name.clone(),
+            content,
+        })),
+        Err(e) => Ok(HttpResponse::InternalServerError().json(serde_json::json!({
+            "error": format!("Failed to read agent file: {}", e)
+        }))),
+    }
+}
+
 /// Response structure for agent token statistics
 #[derive(Debug, Serialize)]
 pub struct AgentTokenStatsResponse {

--- a/src/api.rs
+++ b/src/api.rs
@@ -1471,13 +1471,15 @@ pub async fn get_agent_content(
     let agent_id = agent_id.into_inner();
     debug!("Fetching content for agent: {}", agent_id);
 
-    // Validate agent ID to prevent path traversal (allow only safe characters)
-    if !agent_id
-        .chars()
-        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
-    {
+    // Validate agent_id to prevent path traversal and invalid characters
+    // Allow only alphanumerics, underscore, and hyphen.
+    let is_valid_agent_id = !agent_id.is_empty()
+        && agent_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+    if !is_valid_agent_id {
         return Ok(HttpResponse::BadRequest().json(serde_json::json!({
-            "error": "Invalid agent ID"
+            "error": "Invalid agent id"
         })));
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1495,6 +1495,26 @@ pub async fn get_agent_content(
     let agents_dir = crate::agent::get_agents_dir(app_config.config_dir.as_deref());
     let agent_file = agents_dir.join(format!("{}.md", agent_id));
 
+    // Resolve symlinks and canonicalize paths to prevent traversal
+    let agents_dir = agents_dir.canonicalize().map_err(|e| {
+        actix_web::error::ErrorInternalServerError(format!("Agents directory not found: {}", e))
+    })?;
+    let agent_file = match agent_file.canonicalize() {
+        Ok(p) => p,
+        Err(_) => {
+            return Ok(HttpResponse::NotFound().json(serde_json::json!({
+                "error": format!("Agent '{}' not found", agent_id)
+            })));
+        }
+    };
+
+    // Ensure the resolved path is still within the agents directory
+    if !agent_file.starts_with(&agents_dir) {
+        return Ok(HttpResponse::Forbidden().json(serde_json::json!({
+            "error": "Access denied"
+        })));
+    }
+
     match std::fs::read_to_string(&agent_file) {
         Ok(content) => Ok(HttpResponse::Ok().json(AgentContentResponse {
             id: agent_id,

--- a/src/server.rs
+++ b/src/server.rs
@@ -289,6 +289,10 @@ pub async fn start_server(
                         "/agents/{agent_id}/stats",
                         web::get().to(api::get_agent_stats_by_id),
                     )
+                    .route(
+                        "/agents/{agent_id}/content",
+                        web::get().to(api::get_agent_content),
+                    )
                     .route("/config", web::get().to(api::get_config))
                     .route("/tool-approval", web::post().to(api::handle_tool_approval))
                     .route(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, useLocation, useNavigate } from 'react-ro
 import ChatBot from './components/app/chatbot';
 import Logs from './components/app/logs';
 import { FileViewer } from './components/app/file-viewer';
+import { AgentViewer } from './components/app/agent-viewer';
 import { AppSidebar } from './components/app/app-sidebar';
 import { FilesSidebar } from './components/app/files-sidebar';
 import { DocumentManager } from './components/app/document-manager';
@@ -30,6 +31,9 @@ function AppContent() {
   const [showFilesPanel, setShowFilesPanel] = useState(false);
   const [showRagPanel, setShowRagPanel] = useState(false);
 
+  // State for selected agent in sidebar
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+
   useEffect(() => {
     void loadSessions();
   }, [loadSessions]);
@@ -57,29 +61,37 @@ function AppContent() {
     }
   };
 
+  const handleAgentSelect = (agentId: string) => {
+    setSelectedAgentId(agentId);
+    navigate(`/agents/${agentId}`);
+  };
+
   const isLogsPage = location.pathname === '/logs';
   const isAgentStatsPage = location.pathname === '/agent-stats';
+  const isAgentViewerPage = location.pathname.startsWith('/agents/');
 
   return (
     <SidebarProvider className="h-full">
-      {!isLogsPage && !isAgentStatsPage && (
+      {(!isLogsPage && !isAgentStatsPage) || isAgentViewerPage ? (
         <AppSidebar
           sessions={sessions}
           onSessionSelect={handleSessionSelect}
           onNewChat={handleNewChat}
           activeSessionId={activeSessionId || undefined}
+          onAgentSelect={handleAgentSelect}
+          selectedAgentId={selectedAgentId || undefined}
         />
-      )}
+      ) : null}
       <SidebarInset className="flex flex-col overflow-hidden">
         <header className="flex h-16 shrink-0 items-center gap-2 border-b">
           <div className="flex flex-1 items-center gap-2 px-4">
-            {!isLogsPage && !isAgentStatsPage && (
+            {!isLogsPage && !isAgentStatsPage && !isAgentViewerPage && (
               <>
                 <SidebarTrigger className="-ml-1" />
                 <Separator orientation="vertical" className="mr-2 h-4" />
               </>
             )}
-            {(isLogsPage || isAgentStatsPage) && (
+            {(isLogsPage || isAgentStatsPage || isAgentViewerPage) && (
               <>
                 <button
                   onClick={() => navigate('/')}
@@ -104,9 +116,15 @@ function AppContent() {
                   Back to Chat
                 </Button>
               ) : null}
+              {isAgentViewerPage ? (
+                <Button variant="ghost" className="flex items-center gap-2" onClick={() => navigate('/')}>
+                  <MessageSquare className="h-4 w-4" />
+                  Back to Chat
+                </Button>
+              ) : null}
             </div>
           </div>
-          {!isLogsPage && !isAgentStatsPage && (
+          {!isLogsPage && !isAgentStatsPage && !isAgentViewerPage && (
             <>
               <Separator orientation="vertical" className="h-4" />
               {isLoaded && ragEnabled && (
@@ -144,15 +162,16 @@ function AppContent() {
               <Route path="/" element={<ChatBot />} />
               <Route path="/logs" element={<Logs />} />
               <Route path="/agent-stats" element={<AgentStatsCard apiUrl="" />} />
+              <Route path="/agents/:id" element={<AgentViewer />} />
               <Route path="/workspace/files/*" element={<FileViewer />} />
             </Routes>
           </div>
-          {!isLogsPage && isLoaded && ragEnabled && showRagPanel && (
+          {!isLogsPage && !isAgentViewerPage && isLoaded && ragEnabled && showRagPanel && (
             <div className="border-l w-96 shrink-0 overflow-auto p-4">
               <DocumentManager />
             </div>
           )}
-          {!isLogsPage && showFilesPanel && (
+          {!isLogsPage && !isAgentViewerPage && showFilesPanel && (
             <div className="border-l w-80 shrink-0">
               <FilesSidebar />
             </div>

--- a/web/src/components/app/agent-viewer.tsx
+++ b/web/src/components/app/agent-viewer.tsx
@@ -1,0 +1,110 @@
+import { useParams } from 'react-router-dom';
+import { useEffect, useState, useCallback } from 'react';
+import { Loader2, Bot, CopyIcon } from 'lucide-react';
+import {
+  Artifact,
+  ArtifactAction,
+  ArtifactActions,
+  ArtifactContent,
+  ArtifactDescription,
+  ArtifactHeader,
+  ArtifactTitle,
+} from '@/components/ai-elements/artifact';
+import { CodeBlock } from '@/components/ai-elements/code-block';
+import { fetchAgentContent, type AgentContentResponse } from '@/lib/chat-api';
+import { toast } from 'sonner';
+
+export function AgentViewer() {
+  const { id: agentId } = useParams<{ id: string }>();
+  const [agentData, setAgentData] = useState<AgentContentResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchContent = async () => {
+      if (!agentId) {
+        setError('No agent ID provided');
+        setLoading(false);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await fetchAgentContent('', agentId);
+        setAgentData(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load agent content');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void fetchContent();
+  }, [agentId]);
+
+  const handleCopy = useCallback(async () => {
+    if (!agentData?.content) return;
+    try {
+      await navigator.clipboard.writeText(agentData.content);
+      toast.success('Copied to clipboard');
+    } catch {
+      toast.error('Failed to copy to clipboard');
+    }
+  }, [agentData?.content]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center flex-1">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center flex-1">
+        <div className="text-sm text-destructive">Error: {error}</div>
+      </div>
+    );
+  }
+
+  if (!agentData) {
+    return (
+      <div className="flex items-center justify-center flex-1">
+        <div className="text-sm text-muted-foreground">Agent not found</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 w-full flex-col overflow-hidden min-h-0 p-4">
+      <Artifact className="flex-1 flex flex-col min-h-0">
+        <ArtifactHeader>
+          <div>
+            <ArtifactTitle>
+              <div className="flex items-center gap-2">
+                <Bot className="h-4 w-4" />
+                <span>{agentData.name}</span>
+              </div>
+            </ArtifactTitle>
+            <ArtifactDescription>Agent: {agentData.id}</ArtifactDescription>
+          </div>
+          <ArtifactActions>
+            <ArtifactAction icon={CopyIcon} label="Copy" onClick={handleCopy} tooltip="Copy to clipboard" />
+          </ArtifactActions>
+        </ArtifactHeader>
+        <ArtifactContent className="p-0 flex-1 min-h-0 overflow-auto">
+          <div className="agent-viewer-wrap">
+            <CodeBlock
+              className="border-none rounded-none"
+              code={agentData.content}
+              language="markdown"
+              showLineNumbers
+            />
+          </div>
+        </ArtifactContent>
+      </Artifact>
+    </div>
+  );
+}

--- a/web/src/components/app/app-sidebar.tsx
+++ b/web/src/components/app/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { MessageSquare, Plus, Pencil, Trash2, MoreHorizontal, Minus } from 'lucide-react';
+import { MessageSquare, Plus, Pencil, Trash2, MoreHorizontal, Minus, Bot } from 'lucide-react';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import {
   Sidebar,
@@ -37,6 +37,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { useSessionStore } from '@/stores/session-store';
+import { useAgentStore } from '@/stores/agent-store';
 import { NavUser } from './nav-user';
 
 interface ChatSession {
@@ -50,9 +51,11 @@ interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onSessionSelect?: (sessionId: string) => void;
   onNewChat?: () => void;
   activeSessionId?: string;
+  onAgentSelect?: (agentId: string) => void;
+  selectedAgentId?: string;
 }
 
-export function AppSidebar({ sessions = [], onSessionSelect, onNewChat, activeSessionId, ...props }: AppSidebarProps) {
+export function AppSidebar({ sessions = [], onSessionSelect, onNewChat, activeSessionId, onAgentSelect, selectedAgentId, ...props }: AppSidebarProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
   const [sessionToDelete, setSessionToDelete] = React.useState<string | null>(null);
   const [editDialogOpen, setEditDialogOpen] = React.useState(false);
@@ -60,6 +63,12 @@ export function AppSidebar({ sessions = [], onSessionSelect, onNewChat, activeSe
   const [editTitle, setEditTitle] = React.useState('');
 
   const { deleteSession, updateSessionTitle } = useSessionStore();
+  const { agents, loadAgents } = useAgentStore();
+
+  // Load agents on mount
+  React.useEffect(() => {
+    void loadAgents();
+  }, [loadAgents]);
 
   const handleDeleteClick = (sessionId: string) => {
     setSessionToDelete(sessionId);
@@ -167,6 +176,55 @@ export function AppSidebar({ sessions = [], onSessionSelect, onNewChat, activeSe
                               </DropdownMenuItem>
                             </DropdownMenuContent>
                           </DropdownMenu>
+                        </SidebarMenuSubItem>
+                      ))
+                    )}
+                  </SidebarMenuSub>
+                </CollapsibleContent>
+              </SidebarMenuItem>
+            </Collapsible>
+            <Collapsible defaultOpen={false} className="group/collapsible">
+              <SidebarMenuItem>
+                <CollapsibleTrigger asChild>
+                  <SidebarMenuButton>
+                    Agents{" "}
+                    <Plus className="ml-auto group-data-[state=open]/collapsible:hidden" />
+                    <Minus className="ml-auto group-data-[state=closed]/collapsible:hidden" />
+                  </SidebarMenuButton>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <SidebarMenuSub className="mx-0 border-l-0 px-1">
+                    {agents.length === 0 ? (
+                      <SidebarMenuSubItem>
+                        <div className="px-2 py-1.5 text-sm text-muted-foreground">No agents available</div>
+                      </SidebarMenuSubItem>
+                    ) : (
+                      agents.map((agent) => (
+                        <SidebarMenuSubItem key={agent.id}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <SidebarMenuSubButton
+                                asChild
+                                isActive={agent.id === selectedAgentId}
+                              >
+                                <button
+                                  className="w-full flex items-center gap-2"
+                                  onClick={() => onAgentSelect?.(agent.id)}
+                                >
+                                  <Bot className="h-4 w-4 shrink-0" />
+                                  <span className="truncate">{agent.name}</span>
+                                </button>
+                              </SidebarMenuSubButton>
+                            </TooltipTrigger>
+                            <TooltipContent side="right" align="start">
+                              <div className="max-w-xs">
+                                <div className="font-medium">{agent.name}</div>
+                                {agent.description && (
+                                  <div className="text-xs text-muted-foreground mt-1">{agent.description}</div>
+                                )}
+                              </div>
+                            </TooltipContent>
+                          </Tooltip>
                         </SidebarMenuSubItem>
                       ))
                     )}

--- a/web/src/components/app/app-sidebar.tsx
+++ b/web/src/components/app/app-sidebar.tsx
@@ -1,18 +1,18 @@
 import * as React from 'react';
-import { ChevronRight, MessageSquare, Plus, Pencil, Trash2, MoreHorizontal } from 'lucide-react';
+import { MessageSquare, Plus, Pencil, Trash2, MoreHorizontal, Minus } from 'lucide-react';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
-  SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
-  SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
   SidebarRail,
 } from '@/components/ui/sidebar';
 import { Button } from '@/components/ui/button';
@@ -109,71 +109,73 @@ export function AppSidebar({ sessions = [], onSessionSelect, onNewChat, activeSe
           New Chat
         </Button>
       </SidebarHeader>
-      <SidebarContent className="gap-0">
-        <Collapsible defaultOpen className="group/collapsible">
-          <SidebarGroup>
-            <SidebarGroupLabel
-              asChild
-              className="group/label text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-sm"
-            >
-              <CollapsibleTrigger>
-                Chats
-                <ChevronRight className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90" />
-              </CollapsibleTrigger>
-            </SidebarGroupLabel>
-            <CollapsibleContent>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  {sessions.length === 0 ? (
-                    <SidebarMenuItem>
-                      <div className="px-2 py-1.5 text-sm text-muted-foreground">No chat sessions yet</div>
-                    </SidebarMenuItem>
-                  ) : (
-                    sessions.map((session) => (
-                      <SidebarMenuItem key={session.id}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <SidebarMenuButton
-                              asChild
-                              isActive={session.id === activeSessionId}
-                              onClick={() => onSessionSelect?.(session.id)}
-                            >
-                              <button className="w-full flex items-center gap-2">
-                                <MessageSquare className="h-4 w-4 shrink-0" />
-                                <span className="truncate">{session.title}</span>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarMenu>
+            <Collapsible defaultOpen className="group/collapsible">
+              <SidebarMenuItem>
+                <CollapsibleTrigger asChild>
+                  <SidebarMenuButton>
+                    Sessions{" "}
+                    <Plus className="ml-auto group-data-[state=open]/collapsible:hidden" />
+                    <Minus className="ml-auto group-data-[state=closed]/collapsible:hidden" />
+                  </SidebarMenuButton>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <SidebarMenuSub className="mx-0 border-l-0 px-1">
+                    {sessions.length === 0 ? (
+                      <SidebarMenuSubItem>
+                        <div className="px-2 py-1.5 text-sm text-muted-foreground">No chat sessions yet</div>
+                      </SidebarMenuSubItem>
+                    ) : (
+                      sessions.map((session) => (
+                        <SidebarMenuSubItem key={session.id} className="group/item relative">
+                          <SidebarMenuSubButton
+                            asChild
+                            isActive={session.id === activeSessionId}
+                          >
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  className="w-full flex items-center gap-2 pr-7"
+                                  onClick={() => onSessionSelect?.(session.id)}
+                                >
+                                  <MessageSquare className="h-4 w-4 shrink-0" />
+                                  <span className="truncate">{session.title}</span>
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent side="right" align="start">
+                                {session.title}
+                              </TooltipContent>
+                            </Tooltip>
+                          </SidebarMenuSubButton>
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <button className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover/item:opacity-100 transition-opacity p-1 hover:bg-sidebar-accent rounded">
+                                <MoreHorizontal className="h-4 w-4" />
+                                <span className="sr-only">More</span>
                               </button>
-                            </SidebarMenuButton>
-                          </TooltipTrigger>
-                          <TooltipContent side="right" align="start">
-                            {session.title}
-                          </TooltipContent>
-                        </Tooltip>
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <SidebarMenuAction showOnHover>
-                              <MoreHorizontal />
-                              <span className="sr-only">More</span>
-                            </SidebarMenuAction>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent side="right" align="start">
-                            <DropdownMenuItem onClick={() => handleEditClick(session)}>
-                              <Pencil className="h-4 w-4" />
-                              <span>Rename</span>
-                            </DropdownMenuItem>
-                            <DropdownMenuItem variant="destructive" onClick={() => handleDeleteClick(session.id)}>
-                              <Trash2 className="h-4 w-4" />
-                              <span>Delete</span>
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </SidebarMenuItem>
-                    ))
-                  )}
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </CollapsibleContent>
-          </SidebarGroup>
-        </Collapsible>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent side="right" align="start">
+                              <DropdownMenuItem onClick={() => handleEditClick(session)}>
+                                <Pencil className="h-4 w-4" />
+                                <span>Rename</span>
+                              </DropdownMenuItem>
+                              <DropdownMenuItem variant="destructive" onClick={() => handleDeleteClick(session.id)}>
+                                <Trash2 className="h-4 w-4" />
+                                <span>Delete</span>
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </SidebarMenuSubItem>
+                      ))
+                    )}
+                  </SidebarMenuSub>
+                </CollapsibleContent>
+              </SidebarMenuItem>
+            </Collapsible>
+          </SidebarMenu>
+        </SidebarGroup>
       </SidebarContent>
       <SidebarFooter>
         <NavUser user={data.user} />

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -118,11 +118,27 @@
   * {
     @apply border-border outline-ring/50;
   }
+
   html,
   body,
   #root {
     @apply bg-background text-foreground;
     height: 100%;
     overflow: hidden;
+  }
+}
+
+@layer components {
+  .agent-viewer-wrap pre {
+    white-space: pre-wrap !important;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+  }
+
+  .agent-viewer-wrap code,
+  .agent-viewer-wrap code span {
+    white-space: pre-wrap !important;
+    word-break: break-word;
+    overflow-wrap: anywhere;
   }
 }

--- a/web/src/lib/chat-api.ts
+++ b/web/src/lib/chat-api.ts
@@ -663,6 +663,30 @@ export async function fetchAgentStats(apiUrl: string, agentId: string): Promise<
   }
 }
 
+export interface AgentContentResponse {
+  id: string;
+  name: string;
+  content: string;
+}
+
+/**
+ * Fetch the raw markdown content for a specific agent
+ *
+ * @param apiUrl - The base URL of the Squid API. Use empty string '' for relative path (same origin)
+ * @param agentId - The ID of the agent to fetch
+ * @returns Promise with agent content
+ */
+export async function fetchAgentContent(apiUrl: string, agentId: string): Promise<AgentContentResponse> {
+  const endpoint = apiUrl ? `${apiUrl}/api/agents/${agentId}/content` : `/api/agents/${agentId}/content`;
+  const response = await fetch(endpoint);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch agent content: HTTP ${response.status}`);
+  }
+
+  return response.json();
+}
+
 export interface ConfigResponse {
   api_url: string;
   context_window: number;


### PR DESCRIPTION
## Summary

Adds the ability to view agent prompt files directly in the web UI.

### Changes

- **Backend**: New `GET /api/agents/{id}/content` endpoint that reads agent markdown files from the agents directory
- **Sidebar**: New collapsible "Agents" section listing all available agents with Bot icons and tooltips
- **Agent Viewer**: Read-only component that displays the agent's full prompt with syntax highlighting, copy-to-clipboard, and word wrapping for long lines
- **Routing**: New `/agents/:id` route with proper header/sidebar integration
- **Changelog**: Updated with feature entry

### Files Changed

- `src/api.rs` - Agent content endpoint
- `src/server.rs` - Route registration
- `web/src/App.tsx` - Route and layout integration
- `web/src/components/app/app-sidebar.tsx` - Agents sidebar section
- `web/src/components/app/agent-viewer.tsx` - New viewer component
- `web/src/components/ai-elements/code-block.tsx` - Referenced for structure
- `web/src/index.css` - Word wrapping styles
- `web/src/lib/chat-api.ts` - API client function
- `CHANGELOG.md` - Feature entry