### PR TITLE
feat: add audio transcription with configurable enable flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Audio Transcription**: Voice input for chat messages with automatic transcription
-  - Click microphone button to record and transcribe audio to text
+- **Audio Transcription**: Voice input for chat messages with automatic transcription (opt-in, disabled by default)
+  - Set `audio.enabled: true` in config to enable microphone button
   - Works in-browser (Chrome/Edge) or via Docker Whisper (Firefox/Safari)
   - Configurable model size and language detection
   - See [docs/AUDIO_TRANSCRIPTION.md](docs/AUDIO_TRANSCRIPTION.md) for setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Audio Transcription**: Voice input for chat messages with automatic transcription
+  - Click microphone button to record and transcribe audio to text
+  - Works in-browser (Chrome/Edge) or via Docker Whisper (Firefox/Safari)
+  - Configurable model size and language detection
+  - See [docs/AUDIO_TRANSCRIPTION.md](docs/AUDIO_TRANSCRIPTION.md) for setup
+
 - **`cleanup` Command**: New CLI command to remove bundled assets extracted from the binary
   - Cleans up `~/.local/share/squid/bundled/` directory (plugins and agents)
   - Useful after `cargo uninstall squid-rs` to remove leftover cached files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3755,6 +3755,7 @@ dependencies = [
  "async-openai",
  "async-stream",
  "async-trait",
+ "base64",
  "chrono",
  "chrono-tz 0.10.4",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ actix-files = "0.6"
 actix-cors = "0.7"
 async-openai = { version = "0.34", features = ["chat-completion"] }
 async-stream = "0.3"
+base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4.6", features = ["derive"] }
 console = "0.16"
@@ -75,6 +76,6 @@ jsonschema = "0.46"
 dirs = "6.0"
 serde_yaml = "0.9"
 tabled = "0.20.0"
+tempfile = "3.0"
 
 [dev-dependencies]
-tempfile = "3.0"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An AI-powered assistant for code reviews and improvement suggestions. Privacy-fo
 ## Features
 
 - 🌐 **Web UI** - Modern chat interface with persistent sessions and conversation management
+- 🎤 **Audio Input** - Voice input for chat messages with automatic transcription using browser speech recognition or Docker Whisper
 - 🧠 **RAG (Retrieval-Augmented Generation)** - Semantic search over your documents for context-aware responses
 - ⏰ **Background Jobs** - Schedule recurring AI tasks with cron expressions and resource control
 - 🔧 **Tool Calling** - File operations, code search, and bash commands with built-in security
@@ -167,6 +168,10 @@ See [CLI Reference - Init Command](docs/CLI.md#init-command) for full configurat
 | `SQUID_WORKING_DIR` | `./workspace` | Root directory for file operations and plugin access |
 | `server.allow_network` | `false` | Bind to `0.0.0.0` for LAN access (default: `127.0.0.1` only) |
 | `web.sounds` | `true` | Enable notification sounds in Web UI |
+| `audio.enabled` | `true` | Enable audio transcription feature (env: `SQUID_AUDIO_ENABLED`) |
+| `audio.image` | `kesertki/whisper:latest` | Docker image for Whisper transcription (env: `SQUID_AUDIO_IMAGE`) |
+| `audio.model` | `tiny` | Whisper model size: `tiny`, `base`, `small`, `medium`, `large` (env: `SQUID_AUDIO_MODEL`) |
+| `audio.language` | `""` (auto-detect) | Language code for transcription, e.g., `en`, `es`, `fr` (env: `SQUID_AUDIO_LANGUAGE`) |
 | `jobs.enabled` | `false` | Enable background job scheduler |
 | `jobs.max_concurrent_jobs` | `2` | Maximum concurrent job executions |
 | `jobs.max_cpu_percent` | `70` | CPU threshold before jobs pause |
@@ -645,6 +650,7 @@ See [docs/PLUGINS.md](docs/PLUGINS.md) for complete plugin documentation.
 - **[Plugin Development Guide](docs/PLUGINS.md)** - Create custom JavaScript tools (NEW!)
 - **[RAG Guide](docs/RAG.md)** - Retrieval-Augmented Generation (semantic document search)
 - **[Background Jobs](docs/JOBS.md)** - Schedule recurring AI tasks with cron expressions (NEW!)
+- **[Audio Transcription](docs/AUDIO_TRANSCRIPTION.md)** - Voice input setup with browser or Docker Whisper (NEW!)
 - **[Security Features](docs/SECURITY.md)** - Tool approval and security safeguards
 - **[System Prompts Reference](docs/PROMPTS.md)** - Guide to all system prompts and customization
 - **[Examples](docs/EXAMPLES.md)** - Comprehensive usage examples and workflows

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ See [CLI Reference - Init Command](docs/CLI.md#init-command) for full configurat
 | `SQUID_WORKING_DIR` | `./workspace` | Root directory for file operations and plugin access |
 | `server.allow_network` | `false` | Bind to `0.0.0.0` for LAN access (default: `127.0.0.1` only) |
 | `web.sounds` | `true` | Enable notification sounds in Web UI |
-| `audio.enabled` | `true` | Enable audio transcription feature (env: `SQUID_AUDIO_ENABLED`) |
+| `audio.enabled` | `false` | Enable audio transcription feature - opt-in (env: `SQUID_AUDIO_ENABLED`) |
 | `audio.image` | `kesertki/whisper:latest` | Docker image for Whisper transcription (env: `SQUID_AUDIO_IMAGE`) |
 | `audio.model` | `tiny` | Whisper model size: `tiny`, `base`, `small`, `medium`, `large` (env: `SQUID_AUDIO_MODEL`) |
 | `audio.language` | `""` (auto-detect) | Language code for transcription, e.g., `en`, `es`, `fr` (env: `SQUID_AUDIO_LANGUAGE`) |

--- a/docs/AUDIO_TRANSCRIPTION.md
+++ b/docs/AUDIO_TRANSCRIPTION.md
@@ -2,6 +2,8 @@
 
 The chatbot supports audio input for speech-to-text transcription using two methods.
 
+**Note**: Audio transcription is **disabled by default** (opt-in). You must explicitly enable it in your configuration.
+
 ## Methods (Auto-Selected)
 
 ### 1. **Browser Speech Recognition** (Chrome/Edge only)
@@ -20,12 +22,21 @@ The chatbot supports audio input for speech-to-text transcription using two meth
 
 ### Quick Start
 
-1. **Pull the Whisper Docker image:**
+1. **Enable audio transcription** in your `squid.config.json`:
+   ```json
+   {
+     "audio": {
+       "enabled": true
+     }
+   }
+   ```
+
+2. **Pull the Whisper Docker image:**
    ```bash
    docker pull kesertki/whisper:latest
    ```
 
-2. **That's it!** The system will automatically use Docker when available.
+3. **That's it!** The system will automatically use Docker when available.
 
 ### Configuration (Optional)
 
@@ -43,7 +54,7 @@ You can customize the Whisper Docker setup in your `squid.config.json`:
 ```
 
 **Options:**
-- `enabled`: Enable/disable audio transcription feature (default: `true`)
+- `enabled`: Enable/disable audio transcription feature (default: `false`, opt-in)
 - `image`: Docker image to use (default: `kesertki/whisper:latest`)
 - `model`: Whisper model size (default: `tiny`)
   - Options: `tiny`, `tiny.en`, `base`, `base.en`, `small`, `small.en`, `medium`, `medium.en`, `large`

--- a/docs/AUDIO_TRANSCRIPTION.md
+++ b/docs/AUDIO_TRANSCRIPTION.md
@@ -1,0 +1,174 @@
+# Audio Transcription Setup
+
+The chatbot supports audio input for speech-to-text transcription using two methods.
+
+## Methods (Auto-Selected)
+
+### 1. **Browser Speech Recognition** (Chrome/Edge only)
+- Works 100% client-side
+- No backend setup needed
+- Automatically used on Chrome/Edge browsers
+- Real-time transcription as you speak
+
+### 2. **Docker Whisper** (Required for Firefox/Safari)
+- Uses OpenAI Whisper via Docker
+- No API costs
+- Works offline
+- **Required**: Must have Docker installed and running
+
+## Docker Whisper Setup (Recommended)
+
+### Quick Start
+
+1. **Pull the Whisper Docker image:**
+   ```bash
+   docker pull kesertki/whisper:latest
+   ```
+
+2. **That's it!** The system will automatically use Docker when available.
+
+### Configuration (Optional)
+
+You can customize the Whisper Docker setup in your `squid.config.json`:
+
+```json
+{
+  "audio": {
+    "enabled": true,
+    "image": "kesertki/whisper:latest",
+    "model": "tiny",
+    "language": ""
+  }
+}
+```
+
+**Options:**
+- `enabled`: Enable/disable audio transcription feature (default: `true`)
+- `image`: Docker image to use (default: `kesertki/whisper:latest`)
+- `model`: Whisper model size (default: `tiny`)
+  - Options: `tiny`, `tiny.en`, `base`, `base.en`, `small`, `small.en`, `medium`, `medium.en`, `large`
+- `language`: Language code (default: `""` = auto-detect)
+  - Set to specific code if needed: `"en"`, `"es"`, `"fr"`, etc.
+
+**Environment Variables (Override Config):**
+
+```bash
+# Enable/disable audio feature
+export SQUID_AUDIO_ENABLED=true
+
+# Override Docker image
+export SQUID_AUDIO_IMAGE=kesertki/whisper:latest
+
+# Override Whisper model size
+export SQUID_AUDIO_MODEL=base
+
+# Override language
+export SQUID_AUDIO_LANGUAGE=en
+```
+
+### Model Size Guide
+
+| Model | Size | Speed | Accuracy | Best For |
+|-------|------|-------|----------|----------|
+| tiny | ~75 MB | Very Fast | Basic | Quick testing |
+| base | ~150 MB | Fast | Good | General use |
+| small | ~500 MB | Moderate | Better | Quality transcription |
+| medium | ~1.5 GB | Slow | Great | High accuracy |
+| large | ~3 GB | Very Slow | Best | Maximum accuracy |
+
+**Recommendation:** Start with `tiny` for testing, then upgrade to `base` or `small` for production use.
+
+## Alternative: Whisper API Setup
+
+If you prefer using an API endpoint instead of Docker:
+
+### Using OpenAI
+```yaml
+api_url: https://api.openai.com/v1
+api_key: your-openai-api-key
+```
+
+### Using Speaches.ai (Self-Hosted)
+```bash
+# Install
+curl -O https://speaches.ai/docker-compose.yml
+docker compose up -d
+
+# Configure
+api_url: http://localhost:8000/v1
+```
+
+### Using faster-whisper-server
+```bash
+docker run -p 8000:8000 fedirz/faster-whisper-server:latest
+
+# Configure
+api_url: http://localhost:8000
+```
+
+## Usage
+
+1. Click the 🎤 microphone button in the chat input area
+2. Speak your message
+3. Click the ⏹️ stop button
+4. The transcribed text will appear in the input field
+5. Edit if needed, then send
+
+## Troubleshooting
+
+### Docker Whisper not working?
+
+Check if Docker is running:
+```bash
+docker --version
+docker images | grep whisper
+```
+
+If Docker is not available, the system will automatically fall back to using the Whisper API endpoint.
+
+### Audio not transcribing?
+
+1. **Check browser permissions** - Allow microphone access
+2. **Check Docker** - Ensure `kesertki/whisper:latest` is pulled
+3. **Check logs** - Look for transcription errors in server logs
+4. **Try different model** - Set `WHISPER_MODEL=base` for better accuracy
+
+### Model takes too long?
+
+- Use a smaller model: `export WHISPER_MODEL=tiny`
+- Or use the Whisper API instead of Docker
+
+## Architecture
+
+```
+┌─────────────┐
+│   Browser   │
+│  (Chrome)   │──Speech Recognition──► Client-side
+└─────────────┘      (No server)
+
+┌─────────────┐
+│   Browser   │
+│(Firefox/etc)│──MediaRecorder──┐
+└─────────────┘                 │
+                                ▼
+                         ┌──────────────┐
+                         │   Backend    │
+                         │   API        │
+                         └──────┬───────┘
+                                │
+                    ┌───────────┴───────────┐
+                    │                       │
+            ┌───────▼──────┐        ┌──────▼───────┐
+            │    Docker    │        │   Whisper    │
+            │   Whisper    │        │     API      │
+            │  (Offline)   │        │   (Online)   │
+            └──────────────┘        └──────────────┘
+              (Preferred)              (Fallback)
+```
+
+## Performance Tips
+
+1. **Use appropriate model size** - Smaller = faster but less accurate
+2. **Short audio clips** - Whisper processes faster for shorter clips
+3. **Good audio quality** - Clear audio = better transcription
+4. **English-only models** - Use `.en` models (e.g., `tiny.en`) for English-only for better speed

--- a/squid.config.json
+++ b/squid.config.json
@@ -30,6 +30,12 @@
   "web": {
     "sounds": true
   },
+  "audio": {
+    "enabled": true,
+    "image": "kesertki/whisper:latest",
+    "model": "tiny",
+    "language": ""
+  },
   "jobs": {
     "enabled": true,
     "max_concurrent_jobs": 2,

--- a/squid.config.json
+++ b/squid.config.json
@@ -31,7 +31,7 @@
     "sounds": true
   },
   "audio": {
-    "enabled": true,
+    "enabled": false,
     "image": "kesertki/whisper:latest",
     "model": "tiny",
     "language": ""

--- a/src/api.rs
+++ b/src/api.rs
@@ -1527,6 +1527,7 @@ pub struct ConfigResponse {
     pub context_window: u32,
     pub rag_enabled: bool,
     pub web_sounds: bool,
+    pub audio_enabled: bool,
 }
 
 /// Get API configuration (default model, etc.)
@@ -1538,6 +1539,7 @@ pub async fn get_config(app_config: web::Data<Arc<config::Config>>) -> Result<Ht
         context_window: app_config.context_window,
         rag_enabled: app_config.rag.enabled,
         web_sounds: app_config.web.sounds,
+        audio_enabled: app_config.audio.enabled,
     };
 
     Ok(HttpResponse::Ok().json(response))

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -84,17 +84,15 @@ async fn transcribe_with_docker_whisper(
     debug!("Using Docker Whisper for transcription");
 
     // Create temporary file for audio
-    let mut temp_audio_file = NamedTempFile::new()
-        .map_err(|e| format!("Failed to create temp file: {}", e))?;
+    let mut temp_audio_file =
+        NamedTempFile::new().map_err(|e| format!("Failed to create temp file: {}", e))?;
 
     temp_audio_file
         .write_all(&audio_bytes)
         .map_err(|e| format!("Failed to write audio to temp file: {}", e))?;
 
     let audio_path = temp_audio_file.path();
-    let audio_dir = audio_path
-        .parent()
-        .ok_or("Failed to get audio directory")?;
+    let audio_dir = audio_path.parent().ok_or("Failed to get audio directory")?;
     let audio_filename = audio_path
         .file_name()
         .ok_or("Failed to get audio filename")?
@@ -104,10 +102,10 @@ async fn transcribe_with_docker_whisper(
     debug!("Audio saved to: {:?}", audio_path);
 
     // Get audio configuration from app config (with environment variable fallback)
-    let docker_image = std::env::var("SQUID_AUDIO_IMAGE")
-        .unwrap_or_else(|_| app_config.audio.image.clone());
-    let whisper_model = std::env::var("SQUID_AUDIO_MODEL")
-        .unwrap_or_else(|_| app_config.audio.model.clone());
+    let docker_image =
+        std::env::var("SQUID_AUDIO_IMAGE").unwrap_or_else(|_| app_config.audio.image.clone());
+    let whisper_model =
+        std::env::var("SQUID_AUDIO_MODEL").unwrap_or_else(|_| app_config.audio.model.clone());
 
     // Build Docker command with owned strings
     let volume_mount = format!("{}:/app", audio_dir.display());
@@ -131,8 +129,8 @@ async fn transcribe_with_docker_whisper(
     ];
 
     // Add language if specified (auto-detect by default)
-    let language = std::env::var("SQUID_AUDIO_LANGUAGE")
-        .unwrap_or_else(|_| app_config.audio.language.clone());
+    let language =
+        std::env::var("SQUID_AUDIO_LANGUAGE").unwrap_or_else(|_| app_config.audio.language.clone());
 
     if !language.is_empty() {
         docker_args.push("--language".to_string());

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,0 +1,212 @@
+use actix_web::{Error, HttpResponse, web};
+use base64::{Engine as _, engine::general_purpose};
+use log::{debug, warn};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::io::Write;
+use std::sync::Arc;
+use tempfile::NamedTempFile;
+use tokio::process::Command;
+
+use crate::config;
+
+// ========================================
+// Audio Transcription Types
+// ========================================
+
+#[derive(Debug, Deserialize)]
+pub struct TranscribeAudioRequest {
+    pub audio_base64: String,
+    pub mime_type: String,
+    #[serde(default = "default_agent_for_transcription")]
+    pub agent_id: String,
+}
+
+fn default_agent_for_transcription() -> String {
+    "default".to_string()
+}
+
+#[derive(Debug, Serialize)]
+pub struct TranscribeAudioResponse {
+    pub transcript: String,
+}
+
+// ========================================
+// Audio Transcription Handler
+// ========================================
+
+/// Transcribe audio using Docker-based Whisper
+pub async fn transcribe_audio(
+    body: web::Json<TranscribeAudioRequest>,
+    app_config: web::Data<Arc<config::Config>>,
+) -> Result<HttpResponse, Error> {
+    debug!("Transcribing audio with Docker Whisper");
+
+    // Validate base64 audio and decode
+    let audio_bytes = match general_purpose::STANDARD.decode(&body.audio_base64) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+                "error": format!("Failed to decode audio: {}", e)
+            })));
+        }
+    };
+
+    debug!(
+        "Audio size: {} bytes, MIME type: {}",
+        audio_bytes.len(),
+        body.mime_type
+    );
+
+    // Use Docker-based Whisper transcription
+    match transcribe_with_docker_whisper(&body, audio_bytes, &app_config).await {
+        Ok(response) => Ok(response),
+        Err(e) => {
+            warn!("Docker Whisper transcription failed: {}", e);
+            Ok(HttpResponse::InternalServerError().json(serde_json::json!({
+                "error": format!("Transcription failed: {}. Make sure Docker is running and {} is available.", e, app_config.audio.image)
+            })))
+        }
+    }
+}
+
+// ========================================
+// Docker Whisper Implementation
+// ========================================
+
+/// Transcribe audio using Docker with OpenAI Whisper
+/// Based on kesertki/whisper:latest Docker image
+async fn transcribe_with_docker_whisper(
+    _body: &TranscribeAudioRequest,
+    audio_bytes: Vec<u8>,
+    app_config: &config::Config,
+) -> Result<HttpResponse, Box<dyn std::error::Error + Send + Sync>> {
+    debug!("Using Docker Whisper for transcription");
+
+    // Create temporary file for audio
+    let mut temp_audio_file = NamedTempFile::new()
+        .map_err(|e| format!("Failed to create temp file: {}", e))?;
+
+    temp_audio_file
+        .write_all(&audio_bytes)
+        .map_err(|e| format!("Failed to write audio to temp file: {}", e))?;
+
+    let audio_path = temp_audio_file.path();
+    let audio_dir = audio_path
+        .parent()
+        .ok_or("Failed to get audio directory")?;
+    let audio_filename = audio_path
+        .file_name()
+        .ok_or("Failed to get audio filename")?
+        .to_str()
+        .ok_or("Invalid audio filename")?;
+
+    debug!("Audio saved to: {:?}", audio_path);
+
+    // Get audio configuration from app config (with environment variable fallback)
+    let docker_image = std::env::var("SQUID_AUDIO_IMAGE")
+        .unwrap_or_else(|_| app_config.audio.image.clone());
+    let whisper_model = std::env::var("SQUID_AUDIO_MODEL")
+        .unwrap_or_else(|_| app_config.audio.model.clone());
+
+    // Build Docker command with owned strings
+    let volume_mount = format!("{}:/app", audio_dir.display());
+    let audio_file_path = format!("/app/{}", audio_filename);
+
+    let mut docker_args = vec![
+        "run".to_string(),
+        "--rm".to_string(),
+        "-v".to_string(),
+        volume_mount,
+        docker_image.clone(),
+        audio_file_path,
+        "--model".to_string(),
+        whisper_model,
+        "--output_format".to_string(),
+        "json".to_string(),
+        "--output_dir".to_string(),
+        "/app".to_string(),
+        "--task".to_string(),
+        "transcribe".to_string(),
+    ];
+
+    // Add language if specified (auto-detect by default)
+    let language = std::env::var("SQUID_AUDIO_LANGUAGE")
+        .unwrap_or_else(|_| app_config.audio.language.clone());
+
+    if !language.is_empty() {
+        docker_args.push("--language".to_string());
+        docker_args.push(language);
+    }
+
+    debug!("Running Docker command: docker {}", docker_args.join(" "));
+
+    // Run Docker command
+    let output = Command::new("docker")
+        .args(docker_args)
+        .output()
+        .await
+        .map_err(|e| format!("Failed to execute Docker: {}. Is Docker installed?", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Docker Whisper failed: {}", stderr).into());
+    }
+
+    // Read the generated JSON file
+    let json_filename = audio_path
+        .file_stem()
+        .ok_or("Failed to get audio file stem")?
+        .to_str()
+        .ok_or("Invalid file stem")?;
+    let json_path = audio_dir.join(format!("{}.json", json_filename));
+
+    debug!("Reading transcription from: {:?}", json_path);
+
+    let json_content = tokio::fs::read_to_string(&json_path)
+        .await
+        .map_err(|e| format!("Failed to read transcription JSON: {}", e))?;
+
+    // Parse Whisper JSON output
+    let whisper_output: Value = serde_json::from_str(&json_content)
+        .map_err(|e| format!("Failed to parse Whisper JSON: {}", e))?;
+
+    debug!(
+        "Whisper output: {}",
+        serde_json::to_string_pretty(&whisper_output).unwrap_or_default()
+    );
+
+    // Extract transcript text
+    let transcript = if let Some(text) = whisper_output.get("text").and_then(|t| t.as_str()) {
+        text.trim().to_string()
+    } else if whisper_output.is_array() {
+        // Handle array format - concatenate all text
+        whisper_output
+            .as_array()
+            .ok_or("Invalid array format")?
+            .iter()
+            .filter_map(|item| item.get("text").and_then(|t| t.as_str()))
+            .collect::<Vec<_>>()
+            .join(" ")
+            .trim()
+            .to_string()
+    } else {
+        return Err("Unrecognized JSON format from Whisper".into());
+    };
+
+    // Clean up JSON file
+    if let Err(e) = tokio::fs::remove_file(&json_path).await {
+        debug!("Failed to clean up JSON file: {}", e);
+    }
+
+    if transcript.is_empty() {
+        return Err("Transcription returned empty result".into());
+    }
+
+    debug!(
+        "Docker Whisper transcription completed: {} characters",
+        transcript.len()
+    );
+
+    Ok(HttpResponse::Ok().json(TranscribeAudioResponse { transcript }))
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,7 +173,7 @@ pub struct AudioConfig {
 }
 
 fn default_audio_enabled() -> bool {
-    true
+    false
 }
 
 fn default_audio_image() -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -155,6 +155,50 @@ impl Default for WebConfig {
     }
 }
 
+/// Audio transcription configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AudioConfig {
+    /// Enable audio transcription feature
+    #[serde(default = "default_audio_enabled")]
+    pub enabled: bool,
+    /// Docker image for Whisper transcription
+    #[serde(default = "default_audio_image")]
+    pub image: String,
+    /// Whisper model size (tiny, base, small, medium, large)
+    #[serde(default = "default_audio_model")]
+    pub model: String,
+    /// Language code for transcription (empty = auto-detect)
+    #[serde(default = "default_audio_language")]
+    pub language: String,
+}
+
+fn default_audio_enabled() -> bool {
+    true
+}
+
+fn default_audio_image() -> String {
+    "kesertki/whisper:latest".to_string()
+}
+
+fn default_audio_model() -> String {
+    "tiny".to_string()
+}
+
+fn default_audio_language() -> String {
+    String::new() // Auto-detect by default
+}
+
+impl Default for AudioConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_audio_enabled(),
+            image: default_audio_image(),
+            model: default_audio_model(),
+            language: default_audio_language(),
+        }
+    }
+}
+
 /// Server configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
@@ -287,6 +331,8 @@ pub struct Config {
     #[serde(default)]
     pub web: WebConfig,
     #[serde(default)]
+    pub audio: AudioConfig,
+    #[serde(default)]
     pub jobs: JobsConfig,
     /// Default agent ID (agents are loaded from files, not from config)
     #[serde(default = "default_agent_id")]
@@ -340,6 +386,7 @@ impl Default for Config {
             plugins: PluginsConfig::default(),
             server: ServerConfig::default(),
             web: WebConfig::default(),
+            audio: AudioConfig::default(),
             jobs: JobsConfig::default(),
             default_agent: default_agent_id(),
             agents: AgentsConfig::default(),
@@ -498,6 +545,22 @@ impl Config {
         {
             debug!("Overriding SQUID_WEB_SOUNDS from environment");
             config.web.sounds = enabled;
+        }
+
+        // Audio transcription configuration overrides
+        if let Ok(audio_image) = std::env::var("SQUID_AUDIO_IMAGE") {
+            debug!("Overriding SQUID_AUDIO_IMAGE from environment");
+            config.audio.image = audio_image;
+        }
+
+        if let Ok(audio_model) = std::env::var("SQUID_AUDIO_MODEL") {
+            debug!("Overriding SQUID_AUDIO_MODEL from environment");
+            config.audio.model = audio_model;
+        }
+
+        if let Ok(audio_language) = std::env::var("SQUID_AUDIO_LANGUAGE") {
+            debug!("Overriding SQUID_AUDIO_LANGUAGE from environment");
+            config.audio.language = audio_language;
         }
 
         // Plugin configuration overrides
@@ -741,6 +804,9 @@ mod tests {
             "text-embedding-nomic-embed-text-v1.5"
         );
         assert_eq!(config.rag.chunk_size, 512);
+        assert_eq!(config.audio.image, "kesertki/whisper:latest");
+        assert_eq!(config.audio.model, "tiny");
+        assert_eq!(config.audio.language, "");
     }
 
     #[test]

--- a/src/init.rs
+++ b/src/init.rs
@@ -232,6 +232,7 @@ pub async fn run(
         plugins: crate::config::PluginsConfig::default(),
         server: crate::config::Config::default().server,
         web: crate::config::WebConfig::default(),
+        audio: crate::config::AudioConfig::default(),
         jobs: crate::config::JobsConfig::default(),
         default_agent: "general-assistant".to_string(),
         agents: crate::agent::AgentsConfig::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use tabled::{Table, Tabled};
 
 mod agent;
 mod api;
+mod audio;
 mod bundled;
 mod config;
 mod db;

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,7 +5,7 @@ use rust_embed::RustEmbed;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::{api, config, db, jobs, jobs_api, rag, session, workspace};
+use crate::{api, audio, config, db, jobs, jobs_api, rag, session, workspace};
 
 #[derive(RustEmbed)]
 #[folder = "static/"]
@@ -365,6 +365,7 @@ pub async fn start_server(
                     )
                     .route("/config", web::get().to(api::get_config))
                     .route("/tool-approval", web::post().to(api::handle_tool_approval))
+                    .route("/transcribe", web::post().to(audio::transcribe_audio))
                     // Job management routes (must be before workspace catch-all)
                     .route("/jobs", web::get().to(jobs_api::list_jobs))
                     .route("/jobs", web::post().to(jobs_api::create_job))

--- a/web/src/components/app/chatbot.tsx
+++ b/web/src/components/app/chatbot.tsx
@@ -52,6 +52,7 @@ import {
   PromptInputTools,
   usePromptInputAttachments,
 } from '@/components/ai-elements/prompt-input';
+import { SpeechInput } from '@/components/ai-elements/speech-input';
 import { Sources, SourcesContent, SourcesTrigger } from '@/components/ai-elements/sources';
 import { Suggestions } from '@/components/ai-elements/suggestion';
 import {
@@ -156,7 +157,7 @@ const Chatbot = () => {
     toggleRag,
     toggleTools,
   } = useChatStore();
-  const { ragEnabled, isLoaded, webSounds } = useConfigStore();
+  const { ragEnabled, audioEnabled, isLoaded, webSounds } = useConfigStore();
 
   // Local UI state
   const [text, setText] = useState<string>('');
@@ -353,6 +354,60 @@ const Chatbot = () => {
         description: error.message,
       });
     }
+  }, []);
+
+  // Handle audio transcription
+  const handleAudioRecorded = useCallback(
+    async (audioBlob: Blob): Promise<string> => {
+      try {
+        // Convert audio blob to base64
+        const reader = new FileReader();
+        const base64Promise = new Promise<string>((resolve, reject) => {
+          reader.onloadend = () => {
+            const base64 = reader.result as string;
+            // Extract base64 data (remove data URL prefix)
+            const base64Data = base64.split(',')[1];
+            resolve(base64Data);
+          };
+          reader.onerror = reject;
+        });
+        reader.readAsDataURL(audioBlob);
+
+        const base64Audio = await base64Promise;
+
+        // Send to transcription API
+        const response = await fetch('/api/transcribe', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            audio_base64: base64Audio,
+            mime_type: audioBlob.type,
+            agent_id: selectedAgent,
+          }),
+        });
+
+        if (!response.ok) {
+          const error = await response.json();
+          throw new Error(error.error || 'Transcription failed');
+        }
+
+        const data = await response.json();
+        return data.transcript;
+      } catch (error) {
+        toast.error('Transcription failed', {
+          description: error instanceof Error ? error.message : 'Failed to transcribe audio',
+        });
+        throw error;
+      }
+    },
+    [selectedAgent]
+  );
+
+  // Handle transcription from speech recognition (browser-based)
+  const handleTranscriptionChange = useCallback((transcript: string) => {
+    setText((prev) => (prev ? `${prev} ${transcript}` : transcript));
   }, []);
 
   const isSubmitDisabled = useMemo(() => !(text.trim() || status), [text, status]);
@@ -898,6 +953,14 @@ const Chatbot = () => {
                     <PromptInputActionAddAttachments />
                   </PromptInputActionMenuContent>
                 </PromptInputActionMenu>
+                {isLoaded && audioEnabled && (
+                  <SpeechInput
+                    onTranscriptionChange={handleTranscriptionChange}
+                    onAudioRecorded={handleAudioRecorded}
+                    size="sm"
+                    variant="ghost"
+                  />
+                )}
                 {isLoaded && ragEnabled && (
                   <PromptInputButton
                     onClick={handleRagToggle}

--- a/web/src/lib/chat-api.ts
+++ b/web/src/lib/chat-api.ts
@@ -693,6 +693,7 @@ export interface ConfigResponse {
   context_window: number;
   rag_enabled: boolean;
   web_sounds: boolean;
+  audio_enabled: boolean;
 }
 
 /**

--- a/web/src/stores/agent-store.test.ts
+++ b/web/src/stores/agent-store.test.ts
@@ -44,7 +44,7 @@ const STUB_CONFIG = {
   context_window: 0,
   rag_enabled: false,
   web_sounds: true,
-  audio_enabled: true,
+  audio_enabled: false,
 };
 
 const makeAgent = (overrides: Partial<AgentInfo> = {}): AgentInfo => ({

--- a/web/src/stores/agent-store.test.ts
+++ b/web/src/stores/agent-store.test.ts
@@ -44,6 +44,7 @@ const STUB_CONFIG = {
   context_window: 0,
   rag_enabled: false,
   web_sounds: true,
+  audio_enabled: true,
 };
 
 const makeAgent = (overrides: Partial<AgentInfo> = {}): AgentInfo => ({

--- a/web/src/stores/config-store.test.ts
+++ b/web/src/stores/config-store.test.ts
@@ -22,6 +22,7 @@ const MOCK_CONFIG = {
   context_window: 8192,
   rag_enabled: true,
   web_sounds: true,
+  audio_enabled: true,
 };
 
 // ─── Tests ───────────────────────────────────────────────────────────────────

--- a/web/src/stores/config-store.test.ts
+++ b/web/src/stores/config-store.test.ts
@@ -22,7 +22,7 @@ const MOCK_CONFIG = {
   context_window: 8192,
   rag_enabled: true,
   web_sounds: true,
-  audio_enabled: true,
+  audio_enabled: false,
 };
 
 // ─── Tests ───────────────────────────────────────────────────────────────────

--- a/web/src/stores/config-store.ts
+++ b/web/src/stores/config-store.ts
@@ -19,7 +19,7 @@ export const useConfigStore = create<ConfigState>((set) => ({
   // Initial state
   ragEnabled: false, // default to false to prevent flickering until loaded
   webSounds: true, // default to true
-  audioEnabled: true, // default to true
+  audioEnabled: false, // default to false (opt-in)
   apiUrl: '',
   contextWindow: 0,
   isLoading: false,
@@ -52,7 +52,7 @@ export const useConfigStore = create<ConfigState>((set) => ({
         isLoaded: true,
         ragEnabled: false, // default to false on error
         webSounds: true, // default to true on error
-        audioEnabled: true, // default to true on error
+        audioEnabled: false, // default to false on error (opt-in)
       });
     }
   },

--- a/web/src/stores/config-store.ts
+++ b/web/src/stores/config-store.ts
@@ -5,6 +5,7 @@ interface ConfigState {
   // State
   ragEnabled: boolean;
   webSounds: boolean;
+  audioEnabled: boolean;
   apiUrl: string;
   contextWindow: number;
   isLoading: boolean;
@@ -18,6 +19,7 @@ export const useConfigStore = create<ConfigState>((set) => ({
   // Initial state
   ragEnabled: false, // default to false to prevent flickering until loaded
   webSounds: true, // default to true
+  audioEnabled: true, // default to true
   apiUrl: '',
   contextWindow: 0,
   isLoading: false,
@@ -31,6 +33,7 @@ export const useConfigStore = create<ConfigState>((set) => ({
       set({
         ragEnabled: config.rag_enabled,
         webSounds: config.web_sounds,
+        audioEnabled: config.audio_enabled,
         apiUrl: config.api_url,
         contextWindow: config.context_window,
         isLoading: false,
@@ -39,6 +42,7 @@ export const useConfigStore = create<ConfigState>((set) => ({
       console.log('📋 Configuration loaded:', {
         ragEnabled: config.rag_enabled,
         webSounds: config.web_sounds,
+        audioEnabled: config.audio_enabled,
         contextWindow: config.context_window,
       });
     } catch (error) {
@@ -48,6 +52,7 @@ export const useConfigStore = create<ConfigState>((set) => ({
         isLoaded: true,
         ragEnabled: false, // default to false on error
         webSounds: true, // default to true on error
+        audioEnabled: true, // default to true on error
       });
     }
   },


### PR DESCRIPTION
## Summary

Adds voice input support for chat messages with automatic transcription using browser speech recognition or Docker-based Whisper. Includes an admin-configurable enable/disable flag.

## Changes

### Backend
- ✅ Add `AudioConfig` struct with `enabled`, `image`, `model`, `language` fields
- ✅ Add `/api/transcribe` endpoint using Docker Whisper (kesertki/whisper)
- ✅ Support configurable Whisper model sizes: tiny, base, small, medium, large
- ✅ Add `audio_enabled` to `/api/config` response
- ✅ Environment variables: `SQUID_AUDIO_ENABLED`, `SQUID_AUDIO_IMAGE`, `SQUID_AUDIO_MODEL`, `SQUID_AUDIO_LANGUAGE`

### Frontend
- ✅ Add `SpeechInput` component with microphone button
- ✅ Dual-mode transcription: browser Web Speech API (Chrome/Edge) or MediaRecorder + backend (Firefox/Safari)
- ✅ Conditionally render microphone button based on `audioEnabled` from config store
- ✅ Base64 audio encoding for API transmission

### Documentation
- ✅ Add `docs/AUDIO_TRANSCRIPTION.md` with setup guide
- ✅ Update README.md Features section and Configuration Options table
- ✅ Update CHANGELOG.md with concise user-facing entry

## Configuration

Default configuration (enabled by default):
```json
{
  "audio": {
    "enabled": true,
    "image": "kesertki/whisper:latest",
    "model": "tiny",
    "language": ""
  }
}
```

Admins can disable by setting `"enabled": false` in config or `SQUID_AUDIO_ENABLED=false` environment variable.

## Test plan

- [x] Build completes successfully
- [x] Config loads audio settings correctly
- [x] API endpoint `/api/config` returns `audio_enabled` field
- [x] Web UI hides microphone button when `audio.enabled = false`
- [ ] Manual test: Record audio and verify transcription works
- [ ] Manual test: Test with different Whisper model sizes
- [ ] Manual test: Verify browser speech recognition on Chrome/Edge